### PR TITLE
turbo driveの挙動に対応させる

### DIFF
--- a/app/javascript/controllers/ants_world_controller.js
+++ b/app/javascript/controllers/ants_world_controller.js
@@ -17,119 +17,208 @@ export default class extends Controller {
     window.addEventListener('DOMContentLoaded', this.init())
   }
 
-  async init() {
-    const element = this.antsWorldElementTarget
+  disconnect() {
+    // キャッシュが残ってしまうrenderer scene削除
+    this.renderer.dispose()
 
+    const cleanMaterial = material => {
+      material.dispose()
+
+      // dispose textures
+      for (const key of Object.keys(material)) {
+        const value = material[key]
+        if (value && typeof value === 'object' && 'minFilter' in value) {
+          value.dispose()
+        }
+      }
+    }
+
+    this.scene.traverse(object => {
+      if (!object.isMesh) return
+
+      object.geometry.dispose()
+
+      if (object.material.isMaterial) {
+        cleanMaterial(object.material)
+      } else {
+        // an array of materials
+        for (const material of object.material) cleanMaterial(material)
+      }
+    })
+
+    // アニメーションの中止
+    cancelAnimationFrame(this.requestID)
+
+    // canvasを取り除く
+    while(this.element.firstChild){
+      this.element.removeChild(this.element.firstChild)
+    }
+  }
+
+  async init() {
     const tweetData = JSON.parse(this.antsWorldElementTarget.dataset.json)
 
+    // requestAnimationFrameの戻り値のIDを格納
+    this.requestID
+
     // 時間を追跡するためのオブジェクト
-    const clock = new THREE.Clock()
+    this.clock = new THREE.Clock()
 
     // raycasterがヒットした際の待機時間監視(60fps = 1秒間に60画描写)
-    let waitFrame = 60
+    this.waitFrame = 60
 
     // シーン作成
-    const scene = new THREE.Scene()
-    scene.background = new THREE.Color( 0xF0F8FF );
+    this.scene = new THREE.Scene()
+    this.scene.background = new THREE.Color( 0xF0F8FF );
 
     // カメラ作成
-    const camera = new THREE.PerspectiveCamera(75)
-    camera.position.setY(1)
-    camera.far = 100
+    this.camera = new THREE.PerspectiveCamera(75)
+    this.camera.position.setY(1)
+    this.camera.far = 100
 
     // レンダラー作成
-    const renderer = new THREE.WebGLRenderer()
+    this.renderer = new THREE.WebGLRenderer()
     // GLTFLoaderを使用する為の設定
-    renderer.outputEncoding = THREE.sRGBEncoding
-    element.appendChild(renderer.domElement)
+    this.renderer.outputEncoding = THREE.sRGBEncoding
+    this.element.appendChild(this.renderer.domElement)
 
     // FPSを表示させる処理
-    const stats = Stats()
-    stats.showPanel(0)
-    Object.assign(stats.dom.style, {
+    this.stats = Stats()
+    this.stats.showPanel(0)
+    Object.assign(this.stats.dom.style, {
       'position': 'fixed',
       'height': 'max-content',
       'top': 'auto',
       'bottom': '0'
     });
-    element.appendChild(stats.dom)
+    this.element.appendChild(this.stats.dom)
 
     // ***** 画面のリサイズ処理 *****
+
+    const onResize = () => {
+      this.renderer.setPixelRatio(window.devicePixelRatio)
+      this.renderer.setSize(this.element.offsetWidth, this.element.offsetHeight)
+      this.camera.aspect = this.element.offsetWidth / this.element.offsetHeight
+      this.camera.updateProjectionMatrix()
+    }
 
     onResize()
 
     window.addEventListener('resize', onResize)
 
-    function onResize() {
-      renderer.setPixelRatio(window.devicePixelRatio)
-      renderer.setSize(element.offsetWidth, element.offsetHeight)
-      camera.aspect = element.offsetWidth / element.offsetHeight
-      camera.updateProjectionMatrix()
-    }
-
     // 環境光源
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.4)
     const directionalLight = new THREE.DirectionalLight(0xffffff);
     directionalLight.position.set(1, 1, 1).normalize()
-    scene.add(ambientLight, directionalLight)
+    this.scene.add(ambientLight, directionalLight)
 
     // ***** 一人称視点 *****
 
-    let moveForward = false,
-        moveBackward = false,
-        moveLeft = false,
-        moveRight = false,
-        // 移動速度
-        velocity = new THREE.Vector3(),
-        // 移動方向
-        direction = new THREE.Vector3()
+    this.moveForward = false
+    this.moveBackward = false
+    this.moveLeft = false
+    this.moveRight = false
+    // 移動速度
+    this.velocity = new THREE.Vector3()
+    // 移動方向
+    this.direction = new THREE.Vector3()
 
-    const controls = new PointerLockControls(camera, renderer.domElement)
+    this.controls = new PointerLockControls(this.camera, this.renderer.domElement)
 
-    element.addEventListener('click', () => {
-      controls.lock()
+    this.element.addEventListener('click', () => {
+      this.controls.lock()
     })
+
+    const onKeyDown = (event) => {
+      switch(event.code) {
+        case 'KeyW':
+          this.moveForward = true
+          break
+        case 'KeyA':
+          this.moveLeft = true
+          break
+        case 'KeyS':
+          this.moveBackward = true
+          break
+        case 'KeyD':
+          this.moveRight = true
+          break
+      }
+    }
+  
+    const onKeyUp = (event) => {
+      switch(event.code) {
+        case 'KeyW':
+          this.moveForward = false
+          break
+        case 'KeyA':
+          this.moveLeft = false
+          break
+        case 'KeyS':
+          this.moveBackward = false
+          break
+        case 'KeyD':
+          this.moveRight = false
+          break
+      }
+    }
 
     document.addEventListener('keydown', onKeyDown)
     document.addEventListener('keyup', onKeyUp)
 
-    const cameraRaycaster = new THREE.Raycaster()
+    this.cameraRaycaster = new THREE.Raycaster()
 
     // ***** モデル作成 *****
 
-    let groundObject,
-        groundScaleFactor,
-        groundCenter,
-        groundAttribute,
-        stoneObjects = [],
-        gltfModelGroups = [],
-        gltfModels = [],
-        collisionModel,
-        mixers = []
+    this.groundObject
+    this.groundScaleFactor
+    this.groundCenter
+    this.groundAttribute
+    this.stoneObjects = []
+    this.gltfModelGroups = []
+    this.gltfModels = []
+    this.collisionModel
+    this.mixers = []
 
     const ground = '/assets/ground/ground.gltf'
     const stone = '/assets/stone/stone.gltf'
     const modelFile = '/assets/ant/original_ant.gltf'
 
-    await createGltfModel(ground, 'ground', 20)
-    await createGltfModel(stone, 'stone', 26)
+    await this.createGltfModel(ground, 'ground', 20)
+    await this.createGltfModel(stone, 'stone', 26)
 
     for(let i = 0; i < tweetData.length; i++) {
-      await createGltfModel(modelFile, 'userModel', 1, tweetData[i])
+      await this.createGltfModel(modelFile, 'userModel', 1, tweetData[i])
     }
 
-    const textBoard  = new TextBoard()
-    scene.add(textBoard.container)
+    this.textBoard  = new TextBoard()
+    this.scene.add(this.textBoard.container)
 
     // ***** Like Bullet(いいね発射) *****
 
-    let bulletDirection = new THREE.Vector3(),
-        likeBullet
+    this.bulletDirection = new THREE.Vector3()
+    this.likeBullet
 
-    const bulletRaycaster = new THREE.Raycaster()
-    bulletRaycaster.far = 0.2
+    this.bulletRaycaster = new THREE.Raycaster()
+    this.bulletRaycaster.far = 0.2
 
-    element.addEventListener('dblclick', shooting)
+    const shooting = () => {
+      if(this.likeBullet) {
+            // 二つ発射されていたら一個目削除
+        this.likeBullet.material.dispose()
+        this.likeBullet.geometry.dispose()
+        this.scene.remove(this.likeBullet)
+          }
+  
+      this.likeBullet = new Heart()
+      this.likeBullet.position.copy(this.camera.position)
+      this.likeBullet.rotation.copy(this.camera.rotation)
+      this.scene.add(this.likeBullet)
+  
+      this.camera.getWorldDirection(this.bulletDirection)
+    }
+
+    this.element.addEventListener('dblclick', shooting)
 
     // ***** 空作成 *****
 
@@ -138,299 +227,249 @@ export default class extends Controller {
     const skyGeometry = new THREE.SphereGeometry(30, 30, 30)
     const skyMaterial = new THREE.MeshBasicMaterial({ map: skyTexture, side: THREE.BackSide });
     const skyMesh = new THREE.Mesh(skyGeometry, skyMaterial)
-    scene.add(skyMesh)
+    this.scene.add(skyMesh)
 
-    animate()
+    this.animate()
+  }
 
-    async function createGltfModel(gltfFile, name, size, data) {
-      const gltfLoader = new GLTFLoader()
-      const gltfModel = await gltfLoader.loadAsync(
-                                                    gltfFile,
-                                                    (xhr) => {
-                                                      console.log( ( Math.trunc(xhr.loaded / xhr.total * 100) ) + '% loaded' )
-                                                    }
-                                                  )
+  async createGltfModel(gltfFile, name, size, data) {
+    const gltfLoader = new GLTFLoader()
+    const gltfModel = await gltfLoader.loadAsync(
+                                                  gltfFile,
+                                                  (xhr) => {
+                                                    console.log( ( Math.trunc(xhr.loaded / xhr.total * 100) ) + '% loaded' )
+                                                  }
+                                                )
 
-      if(gltfModel.animations.length) {
-        // AnimationMixerを作成しAnimationClipのリストを取得
-        const mixer = new THREE.AnimationMixer(gltfModel.scene)
-        // Animation Actionを生成（クリップ（アニメーションデータ）を指定）
-        const action = mixer.clipAction(gltfModel.animations[0])
+    if(gltfModel.animations.length) {
+      // AnimationMixerを作成しAnimationClipのリストを取得
+      const mixer = new THREE.AnimationMixer(gltfModel.scene)
+      // Animation Actionを生成（クリップ（アニメーションデータ）を指定）
+      const action = mixer.clipAction(gltfModel.animations[0])
+
+      action.play()
+
+      this.mixers.push(mixer)
+    }
+
+    // 取得したモデルのサイズを均一にするための計算
+    const box3 = new THREE.Box3()
+    // 世界軸に沿った最小のバウンディングボックスを計算
+    box3.setFromObject( gltfModel.scene )
+
+    // modelを原点の位置に移動
+    const modelCenter = box3.getCenter(new THREE.Vector3())
+    gltfModel.scene.position.set(-modelCenter.x, -modelCenter.y, -modelCenter.z)
+
+    // 原点(0, 0, 0)を持つgroupに挿入
+    const gltfModelGroup = new THREE.Group()
+    gltfModelGroup.add(gltfModel.scene)
+
+    gltfModelGroup.name = name
+
+    // 現物のサイズを出力
+    const width = box3.max.x - box3.min.x
+    const height = box3.max.y - box3.min.y
+    const length = box3.max.z - box3.min.z
+    
+    // 最大値を取得(最大サイズを引数のsizeに)
+    const maxSize = Math.max(width, height, length)
+    const scaleFactor =  size / maxSize
+
+    gltfModelGroup.scale.multiplyScalar(scaleFactor)
+
+    switch(name) {
+      case 'ground':
+        this.groundObject = gltfModelGroup
+        // 地面の倍率と頂点座標を格納
+        this.groundScaleFactor = scaleFactor
+        this.groundCenter = modelCenter
+        this.groundAttribute = gltfModel.scene.children[0].geometry.attributes.position
+        break
+      case 'stone':
+        this.stoneObjects.push(gltfModelGroup)
+        break
+      case 'userModel':
+        // 地面の頂点座標を一つ決める処理
+        const randomIndex = Math.floor(Math.random() * this.groundAttribute.count)
+        const x = (this.groundAttribute.getX(randomIndex) + -this.groundCenter.x) * this.groundScaleFactor
+        const y = (this.groundAttribute.getY(randomIndex) + -this.groundCenter.y) * this.groundScaleFactor
+        const z = (this.groundAttribute.getZ(randomIndex) + -this.groundCenter.z) * this.groundScaleFactor
+
+        // オブジェクトの中心から足元までの距離を求める処理
+        const putHeight = scaleFactor * ( modelCenter.y -box3.min.y )
+        gltfModelGroup.position.set(x, y + putHeight, z)
+
+        // traverseで子孫のMeshにdataを格納する
+        gltfModel.scene.traverse((child) => {
+          if(child.isMesh) {
+            child.userData = {
+              imageUrl: data.image_url,
+              text: data.post,
+              userName: data.user.name
+            }
+          }
+        })
+        this.gltfModelGroups.push(gltfModelGroup)
+        // animation切り替え用
+        this.gltfModels.push(gltfModel)
+        break
+      }
+    this.scene.add(gltfModelGroup)
+  }
+
+  switchAnimation(hitModelScene) {
+    // 配列の要素を全削除する (インデックス0以降のすべての要素を削除)
+    this.mixers.splice(0)
+    for(let i = 0; i < this.gltfModels.length; i++) {
+      if(this.gltfModels[i].animations.length) {
+        const mixer = new THREE.AnimationMixer(this.gltfModels[i].scene)
+        const clipNumber = this.gltfModels[i].scene == hitModelScene ? 1 : 0
+        const action = mixer.clipAction(this.gltfModels[i].animations[clipNumber])
 
         action.play()
 
-        mixers.push(mixer)
-      }
-
-      // 取得したモデルのサイズを均一にするための計算
-      const box3 = new THREE.Box3()
-      // 世界軸に沿った最小のバウンディングボックスを計算
-      box3.setFromObject( gltfModel.scene )
-
-      // modelを原点の位置に移動
-      const modelCenter = box3.getCenter(new THREE.Vector3())
-      gltfModel.scene.position.set(-modelCenter.x, -modelCenter.y, -modelCenter.z)
-
-      // 原点(0, 0, 0)を持つgroupに挿入
-      const gltfModelGroup = new THREE.Group()
-      gltfModelGroup.add(gltfModel.scene)
-
-      gltfModelGroup.name = name
-
-      // 現物のサイズを出力
-      const width = box3.max.x - box3.min.x
-      const height = box3.max.y - box3.min.y
-      const length = box3.max.z - box3.min.z
-      
-      // 最大値を取得(最大サイズを引数のsizeに)
-      const maxSize = Math.max(width, height, length)
-      const scaleFactor =  size / maxSize
-
-      gltfModelGroup.scale.multiplyScalar(scaleFactor)
-
-      switch(name) {
-        case 'ground':
-          groundObject = gltfModelGroup
-          // 地面の倍率と頂点座標を格納
-          groundScaleFactor = scaleFactor
-          groundCenter = modelCenter
-          groundAttribute = gltfModel.scene.children[0].geometry.attributes.position
-          break
-        case 'stone':
-          stoneObjects.push(gltfModelGroup)
-          break
-        case 'userModel':
-          // 地面の頂点座標を一つ決める処理
-          const randomIndex = Math.floor(Math.random() * groundAttribute.count)
-          const x = (groundAttribute.getX(randomIndex) + -groundCenter.x) * groundScaleFactor
-          const y = (groundAttribute.getY(randomIndex) + -groundCenter.y) * groundScaleFactor
-          const z = (groundAttribute.getZ(randomIndex) + -groundCenter.z) * groundScaleFactor
-
-          // オブジェクトの中心から足元までの距離を求める処理
-          const putHeight = scaleFactor * ( modelCenter.y -box3.min.y )
-          gltfModelGroup.position.set(x, y + putHeight, z)
-
-          // traverseで子孫のMeshにdataを格納する
-          gltfModel.scene.traverse((child) => {
-            if(child.isMesh) {
-              child.userData = {
-                imageUrl: data.image_url,
-                text: data.post,
-                userName: data.user.name
-              }
-            }
-          })
-          gltfModelGroups.push(gltfModelGroup)
-          // animation切り替え用
-          gltfModels.push(gltfModel)
-          break
-        }
-      scene.add(gltfModelGroup)
-    }
-
-    function onKeyDown(event) {
-      switch(event.code) {
-        case 'KeyW':
-          moveForward = true
-          break
-        case 'KeyA':
-          moveLeft = true
-          break
-        case 'KeyS':
-          moveBackward = true
-          break
-        case 'KeyD':
-          moveRight = true
-          break
+        this.mixers.push(mixer)
       }
     }
+  }
 
-    function onKeyUp(event) {
-      switch(event.code) {
-        case 'KeyW':
-          moveForward = false
-          break
-        case 'KeyA':
-          moveLeft = false
-          break
-        case 'KeyS':
-          moveBackward = false
-          break
-        case 'KeyD':
-          moveRight = false
-          break
+  collision() {
+    // 前のTweenの処理を中断して、その位置から新しいTweenを実行する
+    TWEEN.removeAll()
+
+    // ベクトルの大きさが1の方向ベクトル取得
+    const cameraDirection = this.camera.getWorldDirection(new THREE.Vector3())
+    const backX = this.camera.position.x - cameraDirection.x
+    const backZ = this.camera.position.z - cameraDirection.z
+
+    new TWEEN.Tween(this.camera.position)
+              .to({x: backX, y: this.camera.position.y, z: backZ}, 1000)
+              .easing(TWEEN.Easing.Back.Out)
+              .start()
+  }
+
+  animate() {
+    const delta = this.clock.getDelta()
+
+    this.requestID = requestAnimationFrame(this.animate.bind(this))
+
+    this.waitFrame++
+
+    ThreeMeshUI.update()
+
+    TWEEN.update()
+    this.stats.update()
+
+    this.renderer.render(this.scene, this.camera)
+
+    if(this.controls.isLocked) {
+      this.direction.z = Number(this.moveForward) - Number(this.moveBackward)
+      this.direction.x = Number(this.moveRight) - Number(this.moveLeft)
+
+      // 減衰(速度の低下)
+      this.velocity.z -= this.velocity.z * 5.0 * delta
+      this.velocity.x -= this.velocity.x * 5.0 * delta
+
+      if(this.moveForward || this.moveBackward) {
+        this.velocity.z -= this.direction.z * 10 * delta
       }
-    }
-
-    function shooting() {
-      if(likeBullet) {
-        // 二つ発射されていたら一個目削除
-        likeBullet.material.dispose()
-        likeBullet.geometry.dispose()
-        scene.remove(likeBullet)
+      if(this.moveRight || this.moveLeft) {
+        this.velocity.x -= this.direction.x * 10 * delta
       }
 
-      likeBullet = new Heart()
-      likeBullet.position.copy(camera.position)
-      likeBullet.rotation.copy(camera.rotation)
-      scene.add(likeBullet)
+      // 速度を元にカメラの前進後進を決める
+      this.controls.moveForward(-this.velocity.z * delta)
+      this.controls.moveRight(-this.velocity.x * delta)
 
-      camera.getWorldDirection(bulletDirection)
-    }
-
-    function switchAnimation(hitModelScene) {
-      // 配列の要素を全削除する (インデックス0以降のすべての要素を削除)
-      mixers.splice(0)
-      for(let i = 0; i < gltfModels.length; i++) {
-        if(gltfModels[i].animations.length) {
-          const mixer = new THREE.AnimationMixer(gltfModels[i].scene)
-          const clipNumber = gltfModels[i].scene == hitModelScene ? 1 : 0
-          const action = mixer.clipAction(gltfModels[i].animations[clipNumber])
-
-          action.play()
-
-          mixers.push(mixer)
+      if(this.mixers) {
+        // getDelta()->.oldTimeが設定されてから経過した秒数を取得し、.oldTimeを現在の時刻に設定
+        for(const mixer of this.mixers) {
+          mixer.update(delta)
         }
       }
-    }
 
-    function collision() {
-      // 前のTweenの処理を中断して、その位置から新しいTweenを実行する
-      TWEEN.removeAll()
+      // ***** 当たり判定 *****
 
-      // ベクトルの大きさが1の方向ベクトル取得
-      const cameraDirection = camera.getWorldDirection(new THREE.Vector3())
-      const backX = camera.position.x - cameraDirection.x
-      const backZ = camera.position.z - cameraDirection.z
+      const nowCameraPosition = new THREE.Vector3()
+      nowCameraPosition.copy(this.camera.position)
+      // yのみ高さを指定するのは、判定のraycasterは下向きになっている為
+      nowCameraPosition.setY(10)
+      this.cameraRaycaster.set(nowCameraPosition, new THREE.Vector3(0, -1, 0))
 
-      new TWEEN.Tween(camera.position)
-                .to({x: backX, y: camera.position.y, z: backZ}, 1000)
-                .easing(TWEEN.Easing.Back.Out)
-                .start()
-    }
+      // *** 地面接触 ***
+      const hitGround = this.cameraRaycaster.intersectObject(this.groundObject)
+      if(hitGround.length > 0) {
+        this.camera.position.setY(0.6 + hitGround[0].point.y)
+      }
 
-    function animate() {
-      const delta = clock.getDelta()
+      // *** 岩接触 ***
+      const hitStone = this.cameraRaycaster.intersectObjects(this.stoneObjects)
+      if(hitStone.length > 0) {
+        this.controls.moveForward(this.velocity.z * delta)
+        this.controls.moveRight(this.velocity.x * delta)
+        this.collision()
+      }
 
-      requestAnimationFrame(animate)
-
-      waitFrame++
-
-      ThreeMeshUI.update()
-
-      TWEEN.update()
-      stats.update()
-
-      renderer.render(scene, camera)
-
-      if(controls.isLocked) {
-        direction.z = Number(moveForward) - Number(moveBackward)
-        direction.x = Number(moveRight) - Number(moveLeft)
-
-        // 減衰(速度の低下)
-        velocity.z -= velocity.z * 5.0 * delta
-        velocity.x -= velocity.x * 5.0 * delta
-
-        if(moveForward || moveBackward) {
-          velocity.z -= direction.z * 10 * delta
+      // *** モデル接触 ***
+      if(this.waitFrame > 60) {
+        const hitModel = this.cameraRaycaster.intersectObjects(this.gltfModelGroups)
+        if(hitModel.length > 0) {
+          // 最小の構成 Mesh(衝突) < Group(gltfModel.scene) < Group(gltfModelGroup)
+          this.collisionModel = hitModel[0].object.parent.parent
+          const userData = hitModel[0].object.userData
+          this.textBoard.setContents(
+            userData.text,
+            userData.userName,
+            userData.imageUrl
+          )
+          this.collision()
+          this.waitFrame = 0
         }
-        if(moveRight || moveLeft) {
-          velocity.x -= direction.x * 10 * delta
+      }
+
+      if(this.collisionModel) {
+        // 親をたどってグループ化されているObjectにlookAtを適用
+        if(this.collisionModel.name == 'userModel') {
+          this.collisionModel.lookAt(this.camera.position)
+          this.textBoard.setTextPosition(this.camera, this.collisionModel.position)
+        } else if(this.collisionModel.parent.name == 'userModel') {
+          this.collisionModel.parent.lookAt(this.camera.position)
+          this.textBoard.setTextPosition(this.camera, this.collisionModel.parent.position)
+        } else if(this.collisionModel.parent.parent.name == 'userModel') {
+          this.collisionModel.parent.parent.lookAt(this.camera.position)
+          this.textBoard.setTextPosition(this.camera, this.collisionModel.parent.parent.position)
         }
+      }
 
-        // 速度を元にカメラの前進後進を決める
-        controls.moveForward(-velocity.z * delta)
-        controls.moveRight(-velocity.x * delta)
+      // *** Like Bullet ***
+      if(this.likeBullet) {
+        this.likeBullet.position.x += this.bulletDirection.x * delta
+        this.likeBullet.position.y += this.bulletDirection.y * delta
+        this.likeBullet.position.z += this.bulletDirection.z * delta
+        this.likeBullet.rotation.z += delta * 2
 
-        if(mixers) {
-          // getDelta()->.oldTimeが設定されてから経過した秒数を取得し、.oldTimeを現在の時刻に設定
-          for(const mixer of mixers) {
-            mixer.update(delta)
-          }
-        }
+        if(this.waitFrame > 60) {
+          this.bulletRaycaster.set(this.likeBullet.position, new THREE.Vector3(0, -1, 0))
+          const bulletHitMesh = this.bulletRaycaster.intersectObjects(this.gltfModelGroups)
+          if(bulletHitMesh.length > 0) {
+                // material, geometryはWebGLRendererにキャッシュされる為削除
+            this.likeBullet.material.dispose()
+            this.likeBullet.geometry.dispose()
+            this.scene.remove(this.likeBullet)
 
-        // ***** 当たり判定 *****
-
-        const nowCameraPosition = new THREE.Vector3()
-        nowCameraPosition.copy(camera.position)
-        // yのみ高さを指定するのは、判定のraycasterは下向きになっている為
-        nowCameraPosition.setY(10)
-        cameraRaycaster.set(nowCameraPosition, new THREE.Vector3(0, -1, 0))
-
-        // *** 地面接触 ***
-        const hitGround = cameraRaycaster.intersectObject(groundObject)
-        if(hitGround.length > 0) {
-          camera.position.setY(0.6 + hitGround[0].point.y)
-        }
-
-        // *** 岩接触 ***
-        const hitStone = cameraRaycaster.intersectObjects(stoneObjects)
-        if(hitStone.length > 0) {
-          controls.moveForward(velocity.z * delta)
-          controls.moveRight(velocity.x * delta)
-          collision()
-        }
-
-        // *** モデル接触 ***
-        if(waitFrame > 60) {
-          const hitModel = cameraRaycaster.intersectObjects(gltfModelGroups)
-          if(hitModel.length > 0) {
             // 最小の構成 Mesh(衝突) < Group(gltfModel.scene) < Group(gltfModelGroup)
-            collisionModel = hitModel[0].object.parent.parent
-            const userData = hitModel[0].object.userData
-            textBoard.setContents(
-              userData.text,
-              userData.userName,
-              userData.imageUrl
-            )
-            collision()
-            waitFrame = 0
-          }
-        }
+            const bulletHitObject = bulletHitMesh[0].object.parent.parent
 
-        if(collisionModel) {
-          // 親をたどってグループ化されているObjectにlookAtを適用
-          if(collisionModel.name == 'userModel') {
-            collisionModel.lookAt(camera.position)
-            textBoard.setTextPosition(camera, collisionModel.position)
-          } else if(collisionModel.parent.name == 'userModel') {
-            collisionModel.parent.lookAt(camera.position)
-            textBoard.setTextPosition(camera, collisionModel.parent.position)
-          } else if(collisionModel.parent.parent.name == 'userModel') {
-            collisionModel.parent.parent.lookAt(camera.position)
-            textBoard.setTextPosition(camera, collisionModel.parent.parent.position)
-          }
-        }
-
-        // *** Like Bullet ***
-        if(likeBullet) {
-          likeBullet.position.x += bulletDirection.x * delta
-          likeBullet.position.y += bulletDirection.y * delta
-          likeBullet.position.z += bulletDirection.z * delta
-          likeBullet.rotation.z += delta * 2
-
-          if(waitFrame > 60) {
-            bulletRaycaster.set(likeBullet.position, new THREE.Vector3(0, -1, 0))
-            const bulletHitMesh = bulletRaycaster.intersectObjects(gltfModelGroups)
-            if(bulletHitMesh.length > 0) {
-              // material, geometryはWebGLRendererにキャッシュされる為削除
-              likeBullet.material.dispose()
-              likeBullet.geometry.dispose()
-              scene.remove(likeBullet)
-
-              // 最小の構成 Mesh(衝突) < Group(gltfModel.scene) < Group(gltfModelGroup)
-              const bulletHitObject = bulletHitMesh[0].object.parent.parent
-
-              // gltfModel.sceneを格納
-              if(bulletHitObject.name == 'userModel') {
-                switchAnimation(bulletHitObject.children)
-              } else if(bulletHitObject.parent.name == 'userModel') {
-                switchAnimation(bulletHitObject)
-              } else if(bulletHitObject.parent.parent.name == 'userModel') {
-                switchAnimation(bulletHitObject.parent)
-              }
-              waitFrame = 0
+            // gltfModel.sceneを格納
+            if(bulletHitObject.name == 'userModel') {
+              this.switchAnimation(bulletHitObject.children)
+            } else if(bulletHitObject.parent.name == 'userModel') {
+              this.switchAnimation(bulletHitObject)
+            } else if(bulletHitObject.parent.parent.name == 'userModel') {
+              this.switchAnimation(bulletHitObject.parent)
             }
+            this.waitFrame = 0
           }
         }
       }

--- a/app/javascript/controllers/world_map_controller.js
+++ b/app/javascript/controllers/world_map_controller.js
@@ -34,8 +34,7 @@ export default class extends Controller {
 
     this.scene.traverse(object => {
       if (!object.isMesh) return
-      
-      console.log('dispose geometry!')
+
       object.geometry.dispose()
 
       if (object.material.isMaterial) {
@@ -46,6 +45,9 @@ export default class extends Controller {
       }
     })
 
+    // アニメーションの中止
+    cancelAnimationFrame(this.requestID)
+
     // canvasを取り除く
     while(this.element.firstChild){
       this.element.removeChild(this.element.firstChild)
@@ -54,6 +56,9 @@ export default class extends Controller {
 
   async init() {
     // ***** three.js setting *****
+
+    // requestAnimationFrameの戻り値のIDを格納
+    this.requestID
 
     // シーンの追加
     this.scene = new THREE.Scene()
@@ -301,7 +306,7 @@ export default class extends Controller {
   }
 
   animate() {
-    requestAnimationFrame(this.animate.bind(this))
+    this.requestID = requestAnimationFrame(this.animate.bind(this))
     this.renderer.render( this.scene, this.camera )
 
     this.controls.update()

--- a/app/javascript/controllers/world_map_controller.js
+++ b/app/javascript/controllers/world_map_controller.js
@@ -16,6 +16,42 @@ export default class extends Controller {
     window.addEventListener('DOMContentLoaded', this.init())
   }
 
+  disconnect() {
+    // キャッシュが残ってしまうrenderer scene削除
+    this.renderer.dispose()
+
+    const cleanMaterial = material => {
+      material.dispose()
+
+      // dispose textures
+      for (const key of Object.keys(material)) {
+        const value = material[key]
+        if (value && typeof value === 'object' && 'minFilter' in value) {
+          value.dispose()
+        }
+      }
+    }
+
+    this.scene.traverse(object => {
+      if (!object.isMesh) return
+      
+      console.log('dispose geometry!')
+      object.geometry.dispose()
+
+      if (object.material.isMaterial) {
+        cleanMaterial(object.material)
+      } else {
+        // an array of materials
+        for (const material of object.material) cleanMaterial(material)
+      }
+    })
+
+    // canvasを取り除く
+    while(this.element.firstChild){
+      this.element.removeChild(this.element.firstChild)
+    }
+  }
+
   async init() {
     // ***** three.js setting *****
 

--- a/app/javascript/controllers/world_map_controller.js
+++ b/app/javascript/controllers/world_map_controller.js
@@ -17,63 +17,52 @@ export default class extends Controller {
   }
 
   async init() {
-    const element = this.japanMapContainerTarget
-
     // ***** three.js setting *****
 
     // シーンの追加
-    const scene = new THREE.Scene()
+    this.scene = new THREE.Scene()
 
     // レンダリング
-    const renderer = new THREE.WebGLRenderer()
-    element.appendChild(renderer.domElement)
+    this.renderer = new THREE.WebGLRenderer()
+    this.element.appendChild(this.renderer.domElement)
 
     // カメラの設定
-    const camera = new THREE.PerspectiveCamera(75)
-    camera.position.set(0, 0, 400)
+    this.camera = new THREE.PerspectiveCamera(75)
+    this.camera.position.set(0, 0, 400)
 
-    const controls = new OrbitControls(
-      camera,
-      renderer.domElement
+    this.controls = new OrbitControls(
+      this.camera,
+      this.renderer.domElement
     )
-    controls.autoRotate = true
+    this.controls.autoRotate = true
 
-    controls.domElement.addEventListener('click', () => {
-      controls.autoRotate = false
+    this.controls.domElement.addEventListener('click', () => {
+      this.controls.autoRotate = false
     })
 
-    scene.add(camera)
+    this.scene.add(this.camera)
 
     // ライトの追加
     const light = new THREE.DirectionalLight(0x006600)
     light.position.set(1, 2, 1).normalize();
 
-    scene.add(light)
+    this.scene.add(light)
 
     // 環境光源
     const ambientLight = new THREE.AmbientLight(0xFFFFFF, 0.5);
-    scene.add(ambientLight);
+    this.scene.add(ambientLight);
 
     // ***** 画面のリサイズ処理 *****
 
-    onResize()
+    this.onResize()
 
-    window.addEventListener('resize', onResize)
-
-    function onResize() {
-      // デバイスのピクセル比を設定しキャンバスのぼやけを防ぐ為の処理
-      renderer.setPixelRatio(window.devicePixelRatio)
-      renderer.setSize(element.clientWidth, element.clientHeight)
-        // カメラのアスペクト比を正す
-      camera.aspect = element.clientWidth / element.clientHeight;
-      camera.updateProjectionMatrix();
-    }
+    window.addEventListener('resize', this.onResize)
 
     // ***** d3.js geoJson to shape *****
 
     // 描画範囲
-    const width = element.clientWidth,
-          height = element.clientHeight
+    const width = this.element.clientWidth,
+          height = this.element.clientHeight
     const scale = 1500
 
     const geoJson = '/assets/japan.geo.json'
@@ -117,7 +106,7 @@ export default class extends Controller {
       bevelSegments: 1
     };
 
-    const japan = new THREE.Group()
+    this.japan = new THREE.Group()
 
     for(let j = 0; j < places.length; j++) {
       const placeMaterial = new THREE.MeshPhongMaterial()
@@ -127,7 +116,7 @@ export default class extends Controller {
       placeMesh.name = places[j].data.name
       placeMesh.userData.name_ja = places[j].data.name_ja
       
-      japan.add(placeMesh)
+      this.japan.add(placeMesh)
 
       // 県の境界線を表示する為の処理
       const lineMaterial = new THREE.LineBasicMaterial({
@@ -136,15 +125,15 @@ export default class extends Controller {
       const edge = new THREE.EdgesGeometry(placeGeometry)
       const line = new THREE.LineSegments(edge, lineMaterial)
 
-      japan.add(line)
+      this.japan.add(line)
     }
 
-    scene.add(japan)
+    this.scene.add(this.japan)
 
     // ***** japanを中心に持ってくる処理 *****
 
     const box3 = new THREE.Box3()
-    box3.setFromObject(japan)
+    box3.setFromObject(this.japan)
 
     // japanの位置がずれている為、position取得
     const centerX = (box3.max.x - box3.min.x) / 2 + box3.min.x
@@ -154,20 +143,18 @@ export default class extends Controller {
     // オブジェクトの位置、回転を更新
     const mat = new THREE.Matrix4()
     mat.makeTranslation(-centerX, -centerY, -centerZ) // XYZ軸で移動する量(回転軸にしたい頂点が原点にくるように平行移動)
-    japan.applyMatrix4(mat)
+    this.japan.applyMatrix4(mat)
     mat.makeRotationFromEuler(new THREE.Euler( Math.PI / 1.2, 0, 0, 'XYZ' )) // X軸を回転軸としてで回転
-    japan.applyMatrix4(mat)
+    this.japan.applyMatrix4(mat)
 
     // ***** オブジェクトとの交差を調べる  *****
 
     // カーソルの座標用のベクトル作成
-    const cursor = new THREE.Vector2()
+    this.cursor = new THREE.Vector2()
 
-    element.addEventListener('mousemove', handleMouseMove)
-
-    function handleMouseMove(event) {
+    const handleMouseMove = (event) => {
       // 要素の寸法とビューポートに対する相対位置に関する情報を返す
-      const rect = element.getBoundingClientRect()
+      const rect = this.element.getBoundingClientRect()
 
       // canvas上のXY座標
       const cursorX = event.clientX - rect.left
@@ -177,33 +164,34 @@ export default class extends Controller {
       const rectHeight = rect.bottom - rect.top
 
       // -1〜+1の範囲で現在のマウス座標を登録
-      cursor.x = ( cursorX / rectWidth ) * 2 - 1
-      cursor.y = -( cursorY / rectHeight ) * 2 + 1
+      this.cursor.x = ( cursorX / rectWidth ) * 2 - 1
+      this.cursor.y = -( cursorY / rectHeight ) * 2 + 1
     }
 
-    const raycaster = new THREE.Raycaster()
+    this.element.addEventListener('mousemove', handleMouseMove)
+
+    this.raycaster = new THREE.Raycaster()
 
     // ***** 地域選択処理 *****
 
-    let intersectionPlace
-    let selectPlace
+    this.intersectionPlace
+    this.selectPlace
 
-    element.addEventListener('click', handleClick)
-
-    function handleClick() {
+    const handleClick = () => {
       // 2回同じ箇所が押された場合の処理
-      if(intersectionPlace == selectPlace && selectPlace) {
-        location.href = `${location.href}/${selectPlace.name.toLowerCase()}`
+      if(this.intersectionPlace == this.selectPlace && this.selectPlace) {
+        location.href = `${location.href}/${this.selectPlace.name.toLowerCase()}`
       }
-      selectPlace = intersectionPlace
+      this.selectPlace = this.intersectionPlace
     }
+
+    this.element.addEventListener('click', handleClick)
 
     // ***** 文字作成雛形 *****
 
     const fontLoader = new FontLoader()
-    const font = await fontLoader.loadAsync('/assets/japanese_font.json')
-    const textMaterial = new THREE.MeshNormalMaterial()
-    let textGeometry, textMesh
+    this.font = await fontLoader.loadAsync('/assets/japanese_font.json')
+    this.textMaterial = new THREE.MeshNormalMaterial()
 
     // ***** 星(パーティクル)追加 *****
 
@@ -231,76 +219,85 @@ export default class extends Controller {
 
     const starMesh = new THREE.Points(starGeometry, starMaterial)
 
-    scene.add(starMesh)
+    this.scene.add(starMesh)
 
-    animate()
+    this.animate()
+  }
 
-    function animate() {
-      requestAnimationFrame(animate)
-      renderer.render( scene, camera )
+  createText(text) {
+    const sceneLast = this.scene.children[this.scene.children.length -1]
 
-      controls.update()
-
-      // マウス位置からまっすぐに伸びる光線ベクトルを生成
-      raycaster.setFromCamera(cursor, camera)
-
-      const intersects = raycaster.intersectObjects(japan.children)
-
-      // ***** マウスホバー時、placeが選択された際の色変更処理 *****
-
-      if(intersects.length == 0) { intersectionPlace = null }
-
-      japan.children.forEach((mesh) => {
-        if(intersects.length > 0 && mesh == intersects[0].object && mesh.name) {
-          mesh.material.color.setHex( 0xff0000 )
-          intersectionPlace = intersects[0].object
-        } else if(intersects.length == 0 && selectPlace == mesh){
-          selectPlace.material.color.setHex( 0xff0000 )
-        } else if(mesh.isLineSegments == true) {
-          return // lineには変更をかけない
-        } else {
-          mesh.material.color.setHex( 0x00ff00 )
-        }
-      })
-
-      if(intersectionPlace) {
-        createText(intersectionPlace.userData.name_ja)
-        changeElementBgColor(intersectionPlace.name)
-      } else if(selectPlace) {
-        createText(selectPlace.userData.name_ja)
-        changeElementBgColor(selectPlace.name)
-      }
+    if(sceneLast.isMesh == true) {
+      this.scene.remove(sceneLast)
+      sceneLast.material.dispose();
+      sceneLast.geometry.dispose();
     }
 
-    function createText(text) {
-      const sceneLast = scene.children[scene.children.length -1]
+    const textGeometry = new TextGeometry(text, {
+      font: this.font,
+      size: 50,
+      height: 30
+    })
 
-      if(sceneLast.isMesh == true) {
-        scene.remove(sceneLast)
-        sceneLast.material.dispose();
-        sceneLast.geometry.dispose();
-      }
+    textGeometry.center()
 
-      textGeometry = new TextGeometry(text, {
-        font: font,
-        size: 50,
-        height: 30
-      })
+    const textMesh = new THREE.Mesh(textGeometry, this.textMaterial)
+  
+    this.scene.add(textMesh)
+  }
 
-      textGeometry.center()
-
-      textMesh = new THREE.Mesh(textGeometry, textMaterial)
-    
-      scene.add(textMesh)
+  changeElementBgColor(placeName) {
+    const removeRedElements = document.getElementsByClassName('bg-danger')
+    for(let i = 0; 0 < removeRedElements.length; i++) {
+      removeRedElements[i].classList.remove('bg-danger')
     }
+    const addRedElement = document.getElementById(`place-name-${placeName.toLowerCase()}`)
+    addRedElement.classList.add('bg-danger')
+  }
 
-    function changeElementBgColor(placeName) {
-      const removeRedElements = document.getElementsByClassName('bg-danger')
-      for(let i = 0; 0 < removeRedElements.length; i++) {
-        removeRedElements[i].classList.remove('bg-danger')
+  onResize() {
+    // デバイスのピクセル比を設定しキャンバスのぼやけを防ぐ為の処理
+    this.renderer.setPixelRatio(window.devicePixelRatio)
+    this.renderer.setSize(this.element.clientWidth, this.element.clientHeight)
+      // カメラのアスペクト比を正す
+    this.camera.aspect = this.element.clientWidth / this.element.clientHeight;
+    this.camera.updateProjectionMatrix();
+  }
+
+  animate() {
+    requestAnimationFrame(this.animate.bind(this))
+    this.renderer.render( this.scene, this.camera )
+
+    this.controls.update()
+
+    // マウス位置からまっすぐに伸びる光線ベクトルを生成
+    this.raycaster.setFromCamera(this.cursor, this.camera)
+
+    const intersects = this.raycaster.intersectObjects(this.japan.children)
+
+    // ***** マウスホバー時、placeが選択された際の色変更処理 *****
+
+    if(intersects.length == 0) { this.intersectionPlace = null }
+
+    this.japan.children.forEach((mesh) => {
+      if(intersects.length > 0 && mesh == intersects[0].object && mesh.name) {
+        mesh.material.color.setHex( 0xff0000 )
+        this.intersectionPlace = intersects[0].object
+      } else if(intersects.length == 0 && this.selectPlace == mesh){
+        this.selectPlace.material.color.setHex( 0xff0000 )
+      } else if(mesh.isLineSegments == true) {
+        return // lineには変更をかけない
+      } else {
+        mesh.material.color.setHex( 0x00ff00 )
       }
-      const addRedElement = document.getElementById(`place-name-${placeName.toLowerCase()}`)
-      addRedElement.classList.add('bg-danger')
+    })
+
+    if(this.intersectionPlace) {
+      this.createText(this.intersectionPlace.userData.name_ja)
+      this.changeElementBgColor(this.intersectionPlace.name)
+    } else if(this.selectPlace) {
+      this.createText(this.selectPlace.userData.name_ja)
+      this.changeElementBgColor(this.selectPlace.name)
     }
   }
 }

--- a/app/javascript/controllers/world_map_controller.js
+++ b/app/javascript/controllers/world_map_controller.js
@@ -95,9 +95,18 @@ export default class extends Controller {
 
     // ***** 画面のリサイズ処理 *****
 
-    this.onResize()
+    const onResize = () => {
+      // デバイスのピクセル比を設定しキャンバスのぼやけを防ぐ為の処理
+      this.renderer.setPixelRatio(window.devicePixelRatio)
+      this.renderer.setSize(this.element.clientWidth, this.element.clientHeight)
+        // カメラのアスペクト比を正す
+      this.camera.aspect = this.element.clientWidth / this.element.clientHeight;
+      this.camera.updateProjectionMatrix();
+    }
 
-    window.addEventListener('resize', this.onResize)
+    onResize()
+
+    window.addEventListener('resize', onResize)
 
     // ***** d3.js geoJson to shape *****
 
@@ -294,15 +303,6 @@ export default class extends Controller {
     }
     const addRedElement = document.getElementById(`place-name-${placeName.toLowerCase()}`)
     addRedElement.classList.add('bg-danger')
-  }
-
-  onResize() {
-    // デバイスのピクセル比を設定しキャンバスのぼやけを防ぐ為の処理
-    this.renderer.setPixelRatio(window.devicePixelRatio)
-    this.renderer.setSize(this.element.clientWidth, this.element.clientHeight)
-      // カメラのアスペクト比を正す
-    this.camera.aspect = this.element.clientWidth / this.element.clientHeight;
-    this.camera.updateProjectionMatrix();
   }
 
   animate() {

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -1,22 +1,22 @@
 header
   nav.navbar.navbar-expand-lg.navbar-light.bg-success.bg-gradient
     .container-fluid
-      = link_to 'Humans Like Ants', root_path, class: "navbar-brand", data: { turbo: false }
+      = link_to 'Humans Like Ants', root_path, class: "navbar-brand"
       button.navbar-toggler[type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation"]
         span.navbar-toggler-icon
       #navbarNavDropdown.collapse.navbar-collapse.flex-row-reverse
         ul.navbar-nav
           li.nav-item
-            = link_to t('users.new.title'), new_user_path, class: 'nav-link', data: { turbo: false }
+            = link_to t('users.new.title'), new_user_path, class: 'nav-link'
           li.nav-item
-            = link_to t('user_sessions.new.title'), login_path, class: 'nav-link', data: { turbo: false }
+            = link_to t('user_sessions.new.title'), login_path, class: 'nav-link'
           li.nav-item.dropdown
-            = link_to '', href: '#', id: 'navbarDropdownMenuLink', class: 'nav-link dropdown-toggle', role: 'button', 'data-bs-toggle': :dropdown, 'aria-expanded': :'false', data: { turbo: false }
+            = link_to '', href: '#', id: 'navbarDropdownMenuLink', class: 'nav-link dropdown-toggle', role: 'button', 'data-bs-toggle': :dropdown, 'aria-expanded': :'false'
               = t('worlds.index.title')
             ul.dropdown-menu[aria-labelledby="navbarDropdownMenuLink"]
               li
-                = link_to '東京', '#', class: 'dropdown-item', data: { turbo: false }
+                = link_to '東京', '#', class: 'dropdown-item'
               li
-                = link_to '千葉', '#', class: 'dropdown-item', data: { turbo: false }
+                = link_to '千葉', '#', class: 'dropdown-item'
               li
-                = link_to '神奈川', '#', class: 'dropdown-item', data: { turbo: false }
+                = link_to '神奈川', '#', class: 'dropdown-item'

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -6,15 +6,15 @@ footer.footer.pt-3.pb-3.bg-success.bg-gradient
           .h3
             | Humans Like Ants
           .pt-1.pb-1
-            = link_to t('worlds.index.title'), worlds_path, class: 'text-decoration-none text-black', data: { turbo: false }
+            = link_to t('worlds.index.title'), worlds_path, class: 'text-decoration-none text-black'
       .col-sm-6.col-12
         .d-flex.flex-column
           .pt-1.pb-1
-            = link_to '利用規約', '#', class: 'text-decoration-none text-black', data: { turbo: false }
+            = link_to '利用規約', '#', class: 'text-decoration-none text-black'
           .pt-1.pb-1
-            = link_to 'プライバシーポリシー', '#', class: 'text-decoration-none text-black', data: { turbo: false }
+            = link_to 'プライバシーポリシー', '#', class: 'text-decoration-none text-black'
           .pt-1.pb-1
-            = link_to 'お問合せ', '#', class: 'text-decoration-none text-black', data: { turbo: false }
+            = link_to 'お問合せ', '#', class: 'text-decoration-none text-black'
       .pt-1.pb-1
         small
           | Copyright © 2022 issei(e) All Rights Reserved.

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,22 +1,22 @@
 header
   nav.navbar.navbar-expand-lg.navbar-light.bg-success.bg-gradient
     .container-fluid
-      = link_to 'Humans Like Ants', root_path, class: "navbar-brand", data: { turbo: false }
+      = link_to 'Humans Like Ants', root_path, class: "navbar-brand"
       button.navbar-toggler[type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation"]
         span.navbar-toggler-icon
       #navbarNavDropdown.collapse.navbar-collapse.flex-row-reverse
         ul.navbar-nav
           li.nav-item
-            = link_to t('profiles.show.title'), profile_path, class: 'nav-link', data: { turbo: false }
+            = link_to t('profiles.show.title'), profile_path, class: 'nav-link'
           li.nav-item
             = link_to t('defaults.logout'), logout_path, class: 'nav-link', data: { turbo_method: :delete }
           li.nav-item.dropdown
-            = link_to '', href: '#', id: 'navbarDropdownMenuLink', class: 'nav-link dropdown-toggle', role: 'button', 'data-bs-toggle': :dropdown, 'aria-expanded': :'false', data: { turbo: false }
+            = link_to '', href: '#', id: 'navbarDropdownMenuLink', class: 'nav-link dropdown-toggle', role: 'button', 'data-bs-toggle': :dropdown, 'aria-expanded': :'false'
               | 地域選択
             ul.dropdown-menu[aria-labelledby="navbarDropdownMenuLink"]
               li
-                = link_to '東京', '#', class: 'dropdown-item', data: { turbo: false }
+                = link_to '東京', '#', class: 'dropdown-item'
               li
-                = link_to '千葉', '#', class: 'dropdown-item', data: { turbo: false }
+                = link_to '千葉', '#', class: 'dropdown-item'
               li
-                = link_to '神奈川', '#', class: 'dropdown-item', data: { turbo: false }
+                = link_to '神奈川', '#', class: 'dropdown-item'

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -5,6 +5,6 @@ h1 Editing user
 br
 
 div
-  => link_to "Show this user", @user, data: { turbo: false }
+  => link_to "Show this user", @user
   '|
-  =< link_to "Back to users", users_path, data: { turbo: false }
+  =< link_to "Back to users", users_path

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,8 +3,8 @@ p style="color: green" = notice
 == render @user
 
 div
-  => link_to "Edit this user", edit_user_path(@user), data: { turbo: false }
+  => link_to "Edit this user", edit_user_path(@user)
   '|
-  =< link_to "Back to users", users_path, data: { turbo: false }
+  =< link_to "Back to users", users_path
 
   = button_to "Destroy this user", @user, method: :delete

--- a/app/views/worlds/_place.html.slim
+++ b/app/views/worlds/_place.html.slim
@@ -1,7 +1,7 @@
 .col.border class="#{world.id % 2 != 0 ? 'bg-light' : 'bg-white'}"
   .d-flex.flex-column.text-center id="place-name-#{world.place}"
     div
-      = link_to world.place_ja, world_path(world.place), data: { turbo: false }
+      = link_to world.place_ja, world_path(world.place)
     div
       | ( #{world.place} )
     div

--- a/app/views/worlds/show.html.slim
+++ b/app/views/worlds/show.html.slim
@@ -17,12 +17,10 @@ h1.text-center.mt-3.mb-3
   = link_to_previous_page @tweets,
                           t('defaults.back_button',
                           amount: @world.tweets_length(@tweets.prev_page)),
-                          data: { turbo: false },
                           class: 'mt-3 mb-1 btn btn-success'
   = link_to_next_page @tweets,
                       t('defaults.next_button',
                       amount: @world.tweets_length(@tweets.next_page)),
-                      data: { turbo: false },
                       class: 'mt-3 mb-1 btn btn-success'
 / id属性tweet-from
 = turbo_frame_tag 'tweet-form' do


### PR DESCRIPTION
# 概要
- リンクに `data: { turbo: false }` を適用させていたため都度importmapで指定したモジュールが読み込まれてしまっていたため修正
  - ブラウザバックした際にturbo driveがHTMLの状態を記憶する為、最終的にjavascriptで生成されたcanvasも戻してしまう為、stimulusのcontrollerの接続が切れた際に、canvasやthree.jsで使用していたメモリの解放を設定
- three.jsの変数をstimulusのメンバ変数にしてstimulusのdisconnect時の処理を実行できるようにした

issue https://github.com/isseiezawa/Humans-Like-Ants/issues/38