### PR TITLE
Three.js Bug fix

### DIFF
--- a/app/assets/stylesheets/canvas.scss
+++ b/app/assets/stylesheets/canvas.scss
@@ -1,3 +1,8 @@
 canvas {
   margin: auto;
 }
+
+canvas#show-avatar-canvas {
+  width: 50vw;
+  height: 50vw;
+}

--- a/app/javascript/controllers/ants_world_controller.js
+++ b/app/javascript/controllers/ants_world_controller.js
@@ -49,6 +49,12 @@ export default class extends Controller {
     // アニメーションの中止
     cancelAnimationFrame(this.requestID)
 
+    if(!this.requestID) {
+      setTimeout(() => {
+        cancelAnimationFrame(this.requestID)
+      }, 1000)
+    }
+
     // canvasを取り除く
     while(this.element.firstChild){
       this.element.removeChild(this.element.firstChild)

--- a/app/javascript/controllers/show_avatar_controller.js
+++ b/app/javascript/controllers/show_avatar_controller.js
@@ -42,11 +42,6 @@ export default class extends Controller {
 
     // アニメーションの中止
     cancelAnimationFrame(this.requestID)
-
-    // canvasを取り除く
-    while(this.element.firstChild){
-      this.element.removeChild(this.element.firstChild)
-    }
   }
 
   async init() {
@@ -63,23 +58,26 @@ export default class extends Controller {
 
     // シーン作成
     this.scene = new THREE.Scene()
-    this.scene.background = new THREE.Color( 0xF0F8FF );
-
-    // カメラ作成
-    this.camera = new THREE.PerspectiveCamera(75, 400 / 400, 0.1, 100)
-    this.camera.position.setZ(1)
+    this.scene.background = new THREE.Color( 0xF0F8FF )
 
     // レンダラー作成
-    this.renderer = new THREE.WebGLRenderer()
+    const canvasElement = document.getElementById('show-avatar-canvas')
+    const canvasWidth = canvasElement.clientWidth,
+          canvasHeight = canvasElement.clientHeight
+
+    this.renderer = new THREE.WebGLRenderer({canvas: canvasElement})
     this.renderer.setPixelRatio(window.devicePixelRatio)
-    this.renderer.setSize(400, 400)
+    this.renderer.setSize(canvasWidth, canvasHeight)
     // GLTFLoaderを使用する為の設定
     this.renderer.outputEncoding = THREE.sRGBEncoding
-    this.element.appendChild(this.renderer.domElement)
+
+    // カメラ作成
+    this.camera = new THREE.PerspectiveCamera(75, canvasWidth / canvasHeight, 0.1, 100)
+    this.camera.position.setZ(1)
 
     // 環境光源
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.4)
-    const directionalLight = new THREE.DirectionalLight(0xffffff);
+    const directionalLight = new THREE.DirectionalLight(0xffffff)
     directionalLight.position.set(1, 1, 1).normalize()
     this.scene.add(ambientLight, directionalLight)
 

--- a/app/javascript/controllers/show_avatar_controller.js
+++ b/app/javascript/controllers/show_avatar_controller.js
@@ -42,6 +42,12 @@ export default class extends Controller {
 
     // アニメーションの中止
     cancelAnimationFrame(this.requestID)
+
+    if(!this.requestID) {
+      setTimeout(() => {
+        cancelAnimationFrame(this.requestID)
+      }, 1000)
+    }
   }
 
   async init() {

--- a/app/javascript/controllers/static_pages_controller.js
+++ b/app/javascript/controllers/static_pages_controller.js
@@ -44,6 +44,12 @@ export default class extends Controller {
     // アニメーションの中止
     cancelAnimationFrame(this.requestID)
 
+    if(!this.requestID) {
+      setTimeout(() => {
+        cancelAnimationFrame(this.requestID)
+      }, 1000)
+    }
+
     // canvasを取り除く
     while(this.element.firstChild){
       this.element.removeChild(this.element.firstChild)

--- a/app/javascript/controllers/world_map_controller.js
+++ b/app/javascript/controllers/world_map_controller.js
@@ -48,6 +48,12 @@ export default class extends Controller {
     // アニメーションの中止
     cancelAnimationFrame(this.requestID)
 
+    if(!this.requestID) {
+      setTimeout(() => {
+        cancelAnimationFrame(this.requestID)
+      }, 1000)
+    }
+
     // canvasを取り除く
     while(this.element.firstChild){
       this.element.removeChild(this.element.firstChild)

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -50,6 +50,7 @@
                 '',
                 data: { controller: 'show-avatar',
                 json: "#{JSON.generate current_user.avatar_to_hash}" }
+              canvas#show-avatar-canvas
               .row
                 .col.my-auto
                   = t('defaults.number_of_vertices')


### PR DESCRIPTION
# 概要
- profile show画面でブラウザバックした際にhotwireがhtmlを復元、canvas要素の他に `vertices` や `wire-frame` のボタンまでdisposeしてしまっていた為修正。
  - canvas要素を設置しそこに描写する処理にした
- three.jsが読み込まれるページで、高速でページ遷移してしまうと `requestAnimationFrame` の `requestID`がない状態で `cancelAnimationFrame`を実行してしまっていた為修正
issue https://github.com/isseiezawa/Humans-Like-Ants/issues/51