### PR TITLE
 岩衝突時ノックバックしない様に修正

### DIFF
--- a/app/javascript/controllers/ants_world_controller.js
+++ b/app/javascript/controllers/ants_world_controller.js
@@ -528,7 +528,6 @@ export default class extends Controller {
       if(hitStone.length > 0) {
         this.controls.moveForward(this.velocity.z * delta)
         this.controls.moveRight(this.velocity.x * delta)
-        this.collision()
       }
 
       // *** モデル接触 ***


### PR DESCRIPTION
# 概要
- 岩衝突を後ろ向きで受けるとノックバックし続けて外に出てしまうバグの修正。静止することにした

issue https://github.com/isseiezawa/Humans-Like-Ants/issues/79