### PR TITLE
ユーザーに紐づくavatar推しポイントタグ機能追加

### DIFF
--- a/app/assets/stylesheets/avatar_tag_list.scss
+++ b/app/assets/stylesheets/avatar_tag_list.scss
@@ -1,0 +1,31 @@
+#avatar-tags-list label {
+  margin: 3px 0;
+  border: 1px dashed #e9e9e9;
+}
+
+.avatar-tag {
+	position: relative;
+	display: inline-block;
+	margin: 0 .6em .6em .6em;
+	padding: .6em .6em .6em 1.2em;
+	line-height: 1;
+	color: #fff;
+	text-decoration: none;
+  background-image: linear-gradient(to right, #243949 0%, #517fa4 100%);
+}
+.avatar-tag:before {
+	position: absolute;
+	top: 0;
+	left: -1em;
+	content: '';
+	border-width: 1.1em 1em 1.1em 0;
+	border-style: solid;
+	border-color: transparent #243949 transparent transparent;
+}
+.avatar-tag:after {
+	position: absolute;
+	top: center;
+	left: 0;
+	content: '●';
+	color: #fff;
+}

--- a/app/assets/stylesheets/body.scss
+++ b/app/assets/stylesheets/body.scss
@@ -131,3 +131,8 @@ h1 span:after {
   right: 0;
   border-width: 10px 10px 0 0;
 }
+
+::placeholder {
+  color: rgb(196, 196, 196);
+  font-size: 0.8em;
+}

--- a/app/assets/stylesheets/body.scss
+++ b/app/assets/stylesheets/body.scss
@@ -17,6 +17,16 @@ body {
   background-size: $dot-space $dot-space;
 }
 
+@media screen and (max-width: 480px) {
+  p, tr, td, div, a, button {
+    font-size: 0.8rem;
+  }
+
+  .btn {
+    font-size: 0.8rem!important;
+  }
+}
+
 .scrollable-menu {
   height: auto;
   max-height: 30vh;

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -20,3 +20,7 @@
   box-sizing: border-box;
   font-size: 14px;
 }
+
+.header-form {
+  background-color: rgb(164, 231, 200)!important;
+}

--- a/app/assets/stylesheets/link.scss
+++ b/app/assets/stylesheets/link.scss
@@ -40,3 +40,23 @@
   color: #ffffff;
   box-shadow: none;
 }
+
+.searched-tag-button {
+  display: inline-block;
+  text-decoration: none;
+  border-radius: 20%;
+  text-align: center;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  margin: 0.5rem;
+  background: #b3413c;
+  color: #ffffff;
+  line-height: 1em;
+  transition: .3s;
+  box-shadow: 2px 2px 2px #666666;
+}
+.searched-tag-button:hover {
+  text-decoration: none;
+  color: #ffffff;
+  box-shadow: none;
+}

--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -1,0 +1,9 @@
+#tagged-users-table {
+  background-color: #96dbb481;
+}
+
+@media screen and (max-width: 480px) {
+  table {
+    font-size: 0.5rem;
+  }
+}

--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -1,9 +1,3 @@
 #tagged-users-table {
   background-color: #96dbb481;
 }
-
-@media screen and (max-width: 480px) {
-  table {
-    font-size: 0.5rem;
-  }
-}

--- a/app/controllers/avatar_tags_controller.rb
+++ b/app/controllers/avatar_tags_controller.rb
@@ -1,9 +1,22 @@
 class AvatarTagsController < ApplicationController
+  before_action :set_avatar_tag, only: %i[show]
+
+  def show
+    @tagged_users = @avatar_tag.tagged_users
+  end
 
   def search
     query = params[:name]
     search_avatar_tags = AvatarTag.where('name LIKE ?', "%#{query}%").limit(5)
     avatar_tags_name = search_avatar_tags.pluck(:name)
     render json: avatar_tags_name
+  end
+
+  private
+
+  def set_avatar_tag
+    @avatar_tag = AvatarTag.find_by!(name: params[:avatar_tag_name])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, danger: t('activerecord.errors.messages.not_found_avatar_tags', param: params[:avatar_tag_name])
   end
 end

--- a/app/controllers/avatar_tags_controller.rb
+++ b/app/controllers/avatar_tags_controller.rb
@@ -7,7 +7,7 @@ class AvatarTagsController < ApplicationController
 
   def search
     query = params[:name]
-    search_avatar_tags = AvatarTag.where('name LIKE ?', "%#{query}%").limit(5)
+    search_avatar_tags = AvatarTag.where('name LIKE ?', "%#{query}%").limit(20)
     avatar_tags_name = search_avatar_tags.pluck(:name)
     render json: avatar_tags_name
   end

--- a/app/controllers/avatar_tags_controller.rb
+++ b/app/controllers/avatar_tags_controller.rb
@@ -2,7 +2,7 @@ class AvatarTagsController < ApplicationController
   before_action :set_avatar_tag, only: %i[show]
 
   def show
-    @tagged_users = @avatar_tag.tagged_users
+    @tagged_users = @avatar_tag.tagged_users.includes(:avatar_tags).with_attached_avatar
   end
 
   def search

--- a/app/controllers/avatar_tags_controller.rb
+++ b/app/controllers/avatar_tags_controller.rb
@@ -1,13 +1,18 @@
 class AvatarTagsController < ApplicationController
   before_action :set_avatar_tag, only: %i[show]
+  skip_before_action :require_login, only: %i[show index search]
 
   def show
     @tagged_users = @avatar_tag.tagged_users.includes(:avatar_tags).with_attached_avatar
   end
 
+  def index
+    @avatar_tags = AvatarTag.includes(:tagged_users).order(id: :desc)
+  end
+
   def search
     query = params[:name]
-    search_avatar_tags = AvatarTag.where('name LIKE ?', "%#{query}%").limit(20)
+    search_avatar_tags = AvatarTag.where('name LIKE ?', "%#{query}%").order(id: :desc).limit(20)
     avatar_tags_name = search_avatar_tags.pluck(:name)
     render json: avatar_tags_name
   end

--- a/app/controllers/avatar_tags_controller.rb
+++ b/app/controllers/avatar_tags_controller.rb
@@ -1,0 +1,9 @@
+class AvatarTagsController < ApplicationController
+
+  def search
+    query = params[:name]
+    search_avatar_tags = AvatarTag.where('name LIKE ?', "%#{query}%").limit(5)
+    avatar_tags_name = search_avatar_tags.pluck(:name)
+    render json: avatar_tags_name
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -34,6 +34,6 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :gender, :twitter_id, :self_introduction, :avatar)
+    params.require(:user).permit(:name, :email, :gender, :twitter_id, :self_introduction, :avatar, avatar_tags_attributes: [:name], avatar_tag_ids: [])
   end
 end

--- a/app/javascript/controllers/avatar_tags_form_controller.js
+++ b/app/javascript/controllers/avatar_tags_form_controller.js
@@ -8,10 +8,10 @@ export default class extends Controller {
     this.tagsListElement = document.getElementById('avatar-tags-list')
     this.selectElement = document.getElementById('select-tag')
 
-    this.avatarTagList()
+    this.searchAvatarTags()
   }
 
-  async avatarTagList() {
+  async searchAvatarTags() {
     const params = this.inputAvatarTagTarget.value
     const response = await fetch(`${location.origin}/avatar_tags/search?name=${params}`)
     const response_json = await response.json()

--- a/app/javascript/controllers/avatar_tags_form_controller.js
+++ b/app/javascript/controllers/avatar_tags_form_controller.js
@@ -20,13 +20,14 @@ export default class extends Controller {
       this.selectElement.removeChild(this.selectElement.lastChild)
     }
 
-    response_json.forEach(tag => {
+    for(let i = 0; i < response_json.length; i++) {
+      if(i > 10) { break }
       const searchedTagElment = document.createElement('a')
       searchedTagElment.classList.add('searched-tag-button')
       searchedTagElment.dataset.action = 'click->avatar-tags-form#setAvatarTag'
-      searchedTagElment.textContent = tag
+      searchedTagElment.textContent = response_json[i]
       this.selectElement.appendChild(searchedTagElment)
-    })
+    }
   }
 
   setAvatarTag(event) {

--- a/app/javascript/controllers/avatar_tags_form_controller.js
+++ b/app/javascript/controllers/avatar_tags_form_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="avatar-tags-form"
+export default class extends Controller {
+  static targets = ['avatarTag']
+
+  connect() {
+    this.tagsListElement = document.getElementById('avatar-tags-list')
+    this.selectElement = document.getElementById('select-tag')
+  }
+
+  async avatarTagList() {
+    const params = this.avatarTagTarget.value
+    const response = await fetch(`${location.origin}/avatar_tags/search?name=${params}`)
+    const response_json = await response.json()
+
+    while(this.selectElement.lastChild) {
+      this.selectElement.removeChild(this.selectElement.lastChild)
+    }
+
+    response_json.forEach(tag => {
+      const searched_tag_elment = document.createElement('a')
+      searched_tag_elment.classList.add('searched-tag-button')
+      searched_tag_elment.dataset.action = 'click->avatar-tags-form#setAvatarTag'
+      searched_tag_elment.textContent = tag
+      this.selectElement.appendChild(searched_tag_elment)
+    })
+  }
+
+  setAvatarTag(event) {
+    const text = event.currentTarget.textContent
+    const textNode = document.createTextNode(text)
+
+    const id = new Date().getTime();
+
+    const label_element = document.createElement('label')
+    label_element.innerHTML = `<input type='checkbox' checked='checked' name='user[avatar_tags_attributes][${id}][name]' value='${text}'>${text}`
+
+    this.tagsListElement.appendChild(label_element)
+  }
+}

--- a/app/javascript/controllers/avatar_tags_form_controller.js
+++ b/app/javascript/controllers/avatar_tags_form_controller.js
@@ -2,15 +2,17 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="avatar-tags-form"
 export default class extends Controller {
-  static targets = ['avatarTag']
+  static targets = ['inputAvatarTag']
 
   connect() {
     this.tagsListElement = document.getElementById('avatar-tags-list')
     this.selectElement = document.getElementById('select-tag')
+
+    this.avatarTagList()
   }
 
   async avatarTagList() {
-    const params = this.avatarTagTarget.value
+    const params = this.inputAvatarTagTarget.value
     const response = await fetch(`${location.origin}/avatar_tags/search?name=${params}`)
     const response_json = await response.json()
 
@@ -29,13 +31,27 @@ export default class extends Controller {
 
   setAvatarTag(event) {
     const text = event.currentTarget.textContent
-    const textNode = document.createTextNode(text)
 
-    const id = new Date().getTime();
+    const id = new Date().getTime()
 
     const label_element = document.createElement('label')
     label_element.innerHTML = `<input type='checkbox' checked='checked' name='user[avatar_tags_attributes][${id}][name]' value='${text}'>${text}`
 
     this.tagsListElement.appendChild(label_element)
+  }
+
+  addAvatarTag() {
+    const input = this.inputAvatarTagTarget
+    const inputValue = input.value.replace(/\s+/g, '')
+    if(inputValue) {
+      const id = new Date().getTime()
+
+      const label_element = document.createElement('label')
+      label_element.innerHTML = `<input type='checkbox' checked='checked' name='user[avatar_tags_attributes][${id}][name]' value='${inputValue}'>${inputValue}`
+
+      this.tagsListElement.appendChild(label_element)
+
+      input.value = ''
+    }
   }
 }

--- a/app/javascript/controllers/avatar_tags_form_controller.js
+++ b/app/javascript/controllers/avatar_tags_form_controller.js
@@ -21,11 +21,11 @@ export default class extends Controller {
     }
 
     response_json.forEach(tag => {
-      const searched_tag_elment = document.createElement('a')
-      searched_tag_elment.classList.add('searched-tag-button')
-      searched_tag_elment.dataset.action = 'click->avatar-tags-form#setAvatarTag'
-      searched_tag_elment.textContent = tag
-      this.selectElement.appendChild(searched_tag_elment)
+      const searchedTagElment = document.createElement('a')
+      searchedTagElment.classList.add('searched-tag-button')
+      searchedTagElment.dataset.action = 'click->avatar-tags-form#setAvatarTag'
+      searchedTagElment.textContent = tag
+      this.selectElement.appendChild(searchedTagElment)
     })
   }
 
@@ -34,10 +34,10 @@ export default class extends Controller {
 
     const id = new Date().getTime()
 
-    const label_element = document.createElement('label')
-    label_element.innerHTML = `<input type='checkbox' checked='checked' name='user[avatar_tags_attributes][${id}][name]' value='${text}'>${text}`
+    const labelElement = document.createElement('label')
+    labelElement.innerHTML = `<input type='checkbox' checked='checked' name='user[avatar_tags_attributes][${id}][name]' value='${text}'>${text}`
 
-    this.tagsListElement.appendChild(label_element)
+    this.tagsListElement.appendChild(labelElement)
   }
 
   addAvatarTag() {
@@ -46,10 +46,10 @@ export default class extends Controller {
     if(inputValue) {
       const id = new Date().getTime()
 
-      const label_element = document.createElement('label')
-      label_element.innerHTML = `<input type='checkbox' checked='checked' name='user[avatar_tags_attributes][${id}][name]' value='${inputValue}'>${inputValue}`
+      const labelElement = document.createElement('label')
+      labelElement.innerHTML = `<input type='checkbox' checked='checked' name='user[avatar_tags_attributes][${id}][name]' value='${inputValue}'>${inputValue}`
 
-      this.tagsListElement.appendChild(label_element)
+      this.tagsListElement.appendChild(labelElement)
 
       input.value = ''
     }

--- a/app/javascript/controllers/header_controller.js
+++ b/app/javascript/controllers/header_controller.js
@@ -13,8 +13,16 @@ export default class extends Controller {
 
     listElement.classList.add('show')
 
-    while(listElement.lastChild) {
-      listElement.removeChild(listElement.lastChild)
+    // #avatar-tags-indexのelement以外を取り除く処理
+    let childrenCount = listElement.childElementCount
+    for(let i = 0; i < childrenCount; i++) {
+      const child = listElement.children[i]
+      
+      if(child.id != 'avatar-tags-index') {
+        child.remove()
+        --childrenCount
+        --i
+      }
     }
 
     for(let i = 0; i < response_json.length; i++) {

--- a/app/javascript/controllers/header_controller.js
+++ b/app/javascript/controllers/header_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="header"
+export default class extends Controller {
+  static targets = ['inputAvatarTag']
+
+  async searchAvatarTags() {
+    const listElement = document.getElementById('avatar-tag-lists')
+    const value = this.inputAvatarTagTarget.value
+
+    const response = await fetch(`${location.origin}/avatar_tags/search?name=${value}`)
+    const response_json = await response.json()
+
+    listElement.classList.add('show')
+
+    while(listElement.lastChild) {
+      listElement.removeChild(listElement.lastChild)
+    }
+
+    for(let i = 0; i < response_json.length; i++) {
+      if(i > 20) { break }
+      const searchedTagElment = document.createElement('li')
+      searchedTagElment.html = `/avatar_tags/${response_json[i]}`
+      searchedTagElment.innerHTML = `<a href='/avatar_tags/${response_json[i]}' class="dropdown-item">${response_json[i]}</a>`
+      listElement.appendChild(searchedTagElment)
+    }
+  }
+}

--- a/app/models/avatar_tag.rb
+++ b/app/models/avatar_tag.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: avatar_tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_avatar_tags_on_name  (name) UNIQUE
+#
+class AvatarTag < ApplicationRecord
+  has_many :avatar_tag_maps, dependent: :destroy
+  has_many :tagged_user, through: :avatar_tag_maps, source: :user
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/avatar_tag.rb
+++ b/app/models/avatar_tag.rb
@@ -13,7 +13,7 @@
 #
 class AvatarTag < ApplicationRecord
   has_many :avatar_tag_maps, dependent: :destroy
-  has_many :tagged_user, through: :avatar_tag_maps, source: :user
+  has_many :tagged_users, through: :avatar_tag_maps, source: :user
 
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/avatar_tag_map.rb
+++ b/app/models/avatar_tag_map.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: avatar_tag_maps
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  avatar_tag_id :bigint           not null
+#  user_id       :bigint           not null
+#
+# Indexes
+#
+#  index_avatar_tag_maps_on_avatar_tag_id              (avatar_tag_id)
+#  index_avatar_tag_maps_on_user_id                    (user_id)
+#  index_avatar_tag_maps_on_user_id_and_avatar_tag_id  (user_id,avatar_tag_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (avatar_tag_id => avatar_tags.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class AvatarTagMap < ApplicationRecord
+  belongs_to :user
+  belongs_to :avatar_tag
+
+  validates :user_id, presence: true, uniqueness: { scope: :avatar_tag_id }
+  validates :avatar_tag_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,8 @@ class User < ApplicationRecord
   has_many :tweets, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_tweets, through: :likes, source: :tweet
+  has_many :avatar_tag_maps, dependent: :destroy
+  has_many :avatar_tags, through: :avatar_tag_maps
 
   has_one_attached :avatar
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,9 @@ class User < ApplicationRecord
   has_many :liked_tweets, through: :likes, source: :tweet
   has_many :avatar_tag_maps, dependent: :destroy
   has_many :avatar_tags, through: :avatar_tag_maps
+  # avatar_tagsテーブルへの同時保存設定
+  accepts_nested_attributes_for :avatar_tag_maps, allow_destroy: true
+  accepts_nested_attributes_for :avatar_tags
 
   has_one_attached :avatar
 
@@ -68,5 +71,19 @@ class User < ApplicationRecord
 
   def like?(tweet_likes)
     tweet_likes.pluck(:user_id).include?(id)
+  end
+
+  # 代入関数を使用
+  def avatar_tags_attributes=(avatar_tags_attributes)
+    # expect {"uniq_id"=>{"name"=>"text"}}
+    avatar_tags_attributes.values.uniq.each do |tag_params|
+      if tag_params['name'].present?
+        # モデル.find_or_create_by(name: 'text')
+        # 条件を指定して初めの1件を取得し1件もなければ作成
+        tag = AvatarTag.find_or_create_by(tag_params)
+
+        avatar_tags << tag unless avatar_tags.exists?(name: tag.name)
+      end
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,13 +77,13 @@ class User < ApplicationRecord
   def avatar_tags_attributes=(avatar_tags_attributes)
     # expect {"uniq_id"=>{"name"=>"text"}}
     avatar_tags_attributes.values.uniq.each do |tag_params|
-      if tag_params['name'].present?
-        # モデル.find_or_create_by(name: 'text')
-        # 条件を指定して初めの1件を取得し1件もなければ作成
-        tag = AvatarTag.find_or_create_by(tag_params)
+      next if tag_params['name'].blank?
 
-        avatar_tags << tag unless avatar_tags.exists?(name: tag.name)
-      end
+      # モデル.find_or_create_by(name: 'text')
+      # 条件を指定して初めの1件を取得し1件もなければ作成
+      tag = AvatarTag.find_or_create_by(tag_params)
+
+      avatar_tags << tag unless avatar_tags.exists?(name: tag.name)
     end
   end
 end

--- a/app/views/avatar_tags/_avatar_tag.html.slim
+++ b/app/views/avatar_tags/_avatar_tag.html.slim
@@ -1,1 +1,2 @@
-= link_to avatar_tag.name, avatar_tag_path(avatar_tag.name), class: 'avatar-tag'
+= link_to avatar_tag_path(avatar_tag.name), class: 'avatar-tag' do
+  = "#{avatar_tag.name} ( #{avatar_tag.tagged_users.length.to_s} )"

--- a/app/views/avatar_tags/_avatar_tag.html.slim
+++ b/app/views/avatar_tags/_avatar_tag.html.slim
@@ -1,0 +1,1 @@
+= link_to avatar_tag.name, avatar_tag_path(avatar_tag.name), class: 'avatar-tag'

--- a/app/views/avatar_tags/_tagged_user.html.slim
+++ b/app/views/avatar_tags/_tagged_user.html.slim
@@ -13,4 +13,4 @@ tr
   td.align-middle
     = tagged_user.avatar.attached? ? '○' : '×'
   td.align-middle.w-25
-    == render partial: 'avatar_tags/avatar_tag', collection: tagged_user.avatar_tags
+    == render partial: 'avatar_tags/avatar_tag', collection: tagged_user.avatar_tags.includes(:tagged_users)

--- a/app/views/avatar_tags/_tagged_user.html.slim
+++ b/app/views/avatar_tags/_tagged_user.html.slim
@@ -1,0 +1,1 @@
+= tagged_user.name

--- a/app/views/avatar_tags/_tagged_user.html.slim
+++ b/app/views/avatar_tags/_tagged_user.html.slim
@@ -1,1 +1,16 @@
-= tagged_user.name
+tr
+  td.align-middle.w-25
+    = link_to tagged_user.name, user_path(tagged_user)
+  td.align-middle
+    = tagged_user.gender_i18n
+  td.align-middle.w-25
+    - if tagged_user.twitter_id?
+      = link_to tagged_user.decorate.to_twitter_url, target: :_blank, rel: 'noopener noreferrer' do
+        i.fa-brands.fa-twitter
+        | ( @#{tagged_user.twitter_id} )
+    - else
+      = t('defaults.not_register')
+  td.align-middle
+    = tagged_user.avatar.attached? ? '○' : '×'
+  td.align-middle.w-25
+    == render partial: 'avatar_tags/avatar_tag', collection: tagged_user.avatar_tags

--- a/app/views/avatar_tags/index.html.slim
+++ b/app/views/avatar_tags/index.html.slim
@@ -1,0 +1,5 @@
+h1.h3.text-center.mt-3.mb-3
+  span
+    = t('.title')
+.d-flex.flex-wrap.justify-content-evenly
+  == render @avatar_tags

--- a/app/views/avatar_tags/show.html.slim
+++ b/app/views/avatar_tags/show.html.slim
@@ -1,4 +1,19 @@
 h1.h3.text-center.mt-3.mb-3
   span
     = t('.title', name: @avatar_tag.name)
-== render partial: 'tagged_user', collection: @tagged_users
+.container-fluid
+  table#tagged-users-table.table.table-sm.table-hover.table-striped.table-bordered.border-secondary.shadow.text-center
+    thead
+      tr
+        th
+          = User.human_attribute_name(:name)
+        th
+          = User.human_attribute_name(:gender)
+        th
+          = User.human_attribute_name(:twitter_id)
+        th
+          = User.human_attribute_name(:avatar)
+        th
+          = AvatarTag.model_name.human
+      tbody
+        == render partial: 'tagged_user', collection: @tagged_users

--- a/app/views/avatar_tags/show.html.slim
+++ b/app/views/avatar_tags/show.html.slim
@@ -1,0 +1,4 @@
+h1.h3.text-center.mt-3.mb-3
+  span
+    = t('.title', name: @avatar_tag.name)
+== render partial: 'tagged_user', collection: @tagged_users

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -60,7 +60,7 @@
                   = avatar_tag.label { avatar_tag.check_box + avatar_tag.text }
               = content_tag :div, '', data: { controller: 'avatar-tags-form' } do
                 .input-group
-                  = text_field_tag nil, nil, data: { avatar_tags_form_target: 'inputAvatarTag', action: 'input->avatar-tags-form#avatarTagList' }, class: 'form-control'
+                  = text_field_tag nil, nil, data: { avatar_tags_form_target: 'inputAvatarTag', action: 'input->avatar-tags-form#searchAvatarTags' }, class: 'form-control'
                   = link_to 'add', 'javascript:void(0)', data: { action: 'click->avatar-tags-form#addAvatarTag' }, class: 'btn btn-outline-secondary'
                 .small.my-1
                   = t('.search_tags')

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -52,4 +52,12 @@
             .mb-3.col-8
               = form.file_field :avatar, accept: '.gltf', class: 'form-control'
             .mb-3.col-8
+              i.fa-solid.fa-tags.me-1
+              #avatar-tags-list
+                = form.collection_check_boxes(:avatar_tag_ids, @user.avatar_tags, :id, :name) do |avatar_tag|
+                  = avatar_tag.label { avatar_tag.check_box + avatar_tag.text }
+              = content_tag :div, '', data: { controller: 'avatar-tags-form' } do
+                = text_field_tag nil, nil, data: { avatar_tags_form_target: 'avatarTag', action: 'input->avatar-tags-form#avatarTagList' }
+                #select-tag
+            .mb-3.col-8
               = form.submit t('defaults.register'), data: { validate_target: 'submitButton' }, class: 'btn btn-success mt-2 w-25'

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -57,7 +57,9 @@
                 = form.collection_check_boxes(:avatar_tag_ids, @user.avatar_tags, :id, :name) do |avatar_tag|
                   = avatar_tag.label { avatar_tag.check_box + avatar_tag.text }
               = content_tag :div, '', data: { controller: 'avatar-tags-form' } do
-                = text_field_tag nil, nil, data: { avatar_tags_form_target: 'avatarTag', action: 'input->avatar-tags-form#avatarTagList' }
+                .input-group
+                  = text_field_tag nil, nil, data: { avatar_tags_form_target: 'inputAvatarTag', action: 'input->avatar-tags-form#avatarTagList' }, class: 'form-control'
+                  = link_to 'add', 'javascript:void(0)', data: { action: 'click->avatar-tags-form#addAvatarTag' }, class: 'btn btn-outline-secondary'
                 #select-tag
             .mb-3.col-8
               = form.submit t('defaults.register'), data: { validate_target: 'submitButton' }, class: 'btn btn-success mt-2 w-25'

--- a/app/views/profiles/edit.html.slim
+++ b/app/views/profiles/edit.html.slim
@@ -53,13 +53,17 @@
               = form.file_field :avatar, accept: '.gltf', class: 'form-control'
             .mb-3.col-8
               i.fa-solid.fa-tags.me-1
-              #avatar-tags-list
+              span
+                = AvatarTag.model_name.human
+              #avatar-tags-list.d-flex.flex-column
                 = form.collection_check_boxes(:avatar_tag_ids, @user.avatar_tags, :id, :name) do |avatar_tag|
                   = avatar_tag.label { avatar_tag.check_box + avatar_tag.text }
               = content_tag :div, '', data: { controller: 'avatar-tags-form' } do
                 .input-group
                   = text_field_tag nil, nil, data: { avatar_tags_form_target: 'inputAvatarTag', action: 'input->avatar-tags-form#avatarTagList' }, class: 'form-control'
                   = link_to 'add', 'javascript:void(0)', data: { action: 'click->avatar-tags-form#addAvatarTag' }, class: 'btn btn-outline-secondary'
+                .small.my-1
+                  = t('.search_tags')
                 #select-tag
             .mb-3.col-8
               = form.submit t('defaults.register'), data: { validate_target: 'submitButton' }, class: 'btn btn-success mt-2 w-25'

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -73,7 +73,7 @@
             i.fa-solid.fa-tags.me-1
             = AvatarTag.model_name.human
           td.text-center
-            == render partial: 'avatar_tags/avatar_tag', collection: current_user.avatar_tags
+            == render partial: 'avatar_tags/avatar_tag', collection: current_user.avatar_tags.includes(:tagged_users)
       = link_to edit_profile_path,
                 class: 'd-block btn btn-success w-25 mx-auto mb-3' do
         i.fa-solid.fa-pen-to-square.me-1

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -68,6 +68,12 @@
                         data: { turbo_method: :delete } do
                 i.fa-solid.fa-trash.me-1
                 = t('.avatar_delete')
+        tr
+          th
+            i.fa-solid.fa-tags.me-1
+            = AvatarTag.model_name.human
+          td.text-center
+            == render partial: 'avatar_tags/avatar_tag', collection: current_user.avatar_tags
       = link_to edit_profile_path,
                 class: 'd-block btn btn-success w-25 mx-auto mb-3' do
         i.fa-solid.fa-pen-to-square.me-1

--- a/app/views/profiles/show.html.slim
+++ b/app/views/profiles/show.html.slim
@@ -8,25 +8,25 @@
         tr
           th
             i.fa-solid.fa-user-pen.me-1
-            = t(User.human_attribute_name(:name))
+            = User.human_attribute_name(:name)
           td
             = current_user.name
         tr
           th
             i.fa-solid.fa-at.me-1
-            = t(User.human_attribute_name(:email))
+            = User.human_attribute_name(:email)
           td
             = current_user.email
         tr
           th
             i.fa-solid.fa-person-half-dress.me-1
-            = t(User.human_attribute_name(:gender))
+            = User.human_attribute_name(:gender)
           td
             = current_user.gender_i18n
         tr
           th
             i.fa-brands.fa-twitter.me-1.text-info
-            = t(User.human_attribute_name(:twitter_id))
+            = User.human_attribute_name(:twitter_id)
           td
             - if current_user.twitter_id?
               = link_to current_user.decorate.to_twitter_url, target: :_blank, rel: 'noopener noreferrer' do
@@ -37,14 +37,14 @@
         tr
           th
             i.fa-solid.fa-pen-to-square.me-1
-            = t(User.human_attribute_name(:self_introduction))
+            = User.human_attribute_name(:self_introduction)
           td
             .m-1.bg-white
             = current_user.self_introduction
         tr
           th
             i.fa-solid.fa-bugs.me-1
-            = t(User.human_attribute_name(:avatar))
+            = User.human_attribute_name(:avatar)
           td.text-center
             = content_tag :div,
                 '',

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -24,3 +24,11 @@ header
               - world_all.each do |world|
                 li
                   = link_to world.place_ja, world_path(world.place), class: 'dropdown-item'
+          li.nav-item
+            = content_tag :div, data: { controller: 'header' }, class: 'input-group d-flex' do
+              = text_field_tag nil, nil, data: { header_target: 'inputAvatarTag', action: 'input->header#searchAvatarTags', bs_toggle: 'dropdown' }, placeholder: "#{t('defaults.avatar_tags_search')}", class: 'form-control dropdpwn-toggle header-form', aria_expanded: false
+              = button_tag data: { bs_toggle: 'dropdown' }, aria_expanded: false, class: 'btn btn-outline-black dropdpwn-toggle' do
+                i.fa-solid.fa-sort-down.small
+              ul#avatar-tag-lists.dropdown-menu.dropdown-menu-end.top-100.start-0.scrollable-menu
+                li#avatar-tags-index.border-bottom
+                  = link_to t('avatar_tags.index.title'), avatar_tags_path, class: 'dropdown-item'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -34,3 +34,5 @@ header
               = button_tag data: { bs_toggle: 'dropdown' }, aria_expanded: false, class: 'btn btn-outline-black dropdpwn-toggle' do
                 i.fa-solid.fa-sort-down.small
               ul#avatar-tag-lists.dropdown-menu.dropdown-menu-end.top-100.start-0.scrollable-menu
+                li#avatar-tags-index.border-bottom
+                  = link_to t('avatar_tags.index.title'), avatar_tags_path, class: 'dropdown-item'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -15,7 +15,7 @@ header
               i.fa-solid.fa-heart.me-1
               = t('users.likes.title')
           li.nav-item
-            = link_to logout_path, class: 'nav-link', data: { turbo_method: :delete } do
+            = link_to logout_path, class: 'nav-link', data: { turbo_method: :delete, turbo_confirm: t('defaults.logout_confirm') } do
               i.fa-solid.fa-right-from-bracket.me-1
               = t('defaults.logout')
           li.nav-item.dropdown
@@ -28,3 +28,9 @@ header
               - world_all.each do |world|
                 li
                   = link_to world.place_ja, world_path(world.place), class: 'dropdown-item'
+          li.nav-item
+            = content_tag :div, data: { controller: 'header' }, class: 'input-group d-flex' do
+              = text_field_tag nil, nil, data: { header_target: 'inputAvatarTag', action: 'input->header#searchAvatarTags', bs_toggle: 'dropdown' }, placeholder: "#{t('defaults.avatar_tags_search')}", class: 'form-control dropdpwn-toggle header-form', aria_expanded: false
+              = button_tag data: { bs_toggle: 'dropdown' }, aria_expanded: false, class: 'btn btn-outline-black dropdpwn-toggle' do
+                i.fa-solid.fa-sort-down.small
+              ul#avatar-tag-lists.dropdown-menu.dropdown-menu-end.top-100.start-0.scrollable-menu

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -53,3 +53,12 @@ table.table.table-primary.table-striped.table-hover
                         class: 'btn btn-secondary my-1 col' do
             i.fa-solid.fa-border-none.me-1
             = t('defaults.wire_frame')
+  tr
+    th
+      i.fa-solid.fa-tags.me-1
+      = AvatarTag.model_name.human
+    td.text-center
+      - if user.avatar_tags.present?
+        == render partial: 'avatar_tags/avatar_tag', collection: user.avatar_tags
+      - else
+        = t('defaults.not_register')

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -59,6 +59,6 @@ table.table.table-primary.table-striped.table-hover
       = AvatarTag.model_name.human
     td.text-center
       - if user.avatar_tags.present?
-        == render partial: 'avatar_tags/avatar_tag', collection: user.avatar_tags
+        == render partial: 'avatar_tags/avatar_tag', collection: user.avatar_tags.includes(:tagged_users)
       - else
         = t('defaults.not_register')

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -5,19 +5,19 @@ table.table.table-primary.table-striped.table-hover
   tr
     th
       i.fa-solid.fa-user-pen.me-1
-      = t(User.human_attribute_name(:name))
+      = User.human_attribute_name(:name)
     td
       = user.name
   tr
     th
       i.fa-solid.fa-person-half-dress.me-1
-      = t(User.human_attribute_name(:gender))
+      = User.human_attribute_name(:gender)
     td
       = user.gender_i18n
   tr
     th
       i.fa-brands.fa-twitter.me-1.text-info
-      = t(User.human_attribute_name(:twitter_id))
+      = User.human_attribute_name(:twitter_id)
     td
       - if user.twitter_id?
         = link_to user.decorate.to_twitter_url, target: :_blank, rel: 'noopener noreferrer' do
@@ -28,14 +28,14 @@ table.table.table-primary.table-striped.table-hover
   tr
     th
       i.fa-solid.fa-pen-to-square.me-1
-      = t(User.human_attribute_name(:self_introduction))
+      = User.human_attribute_name(:self_introduction)
     td
       .m-1.bg-white
       = user.self_introduction
   tr
     th
       i.fa-solid.fa-bugs.me-1
-      = t(User.human_attribute_name(:avatar))
+      = User.human_attribute_name(:avatar)
     td.text-center
       = content_tag :div,
           '',

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -7,8 +7,10 @@ ja:
         less_than: "のファイルサイズを%{count}より小さいサイズにしてください"
         invalid_file_type: "のファイル形式を%{type}にしてください"
         not_found_world: "%{param}という地域名は登録しておりません。"
+        not_found_avatar_tags: "%{param}というタグは存在しておりません。"
     models:
       user: 'ユーザー'
+      avatar_tag: 'アバター推しポイントタグ'
     attributes:
       user:
         id: 'ID'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,8 @@ ja:
     give_birth: '産む'
     login: 'ログイン'
     logout: 'ログアウト'
+    logout_confirm: 'ログアウトしますか?'
+    avatar_tags_search: 'アバター推しポイントタグ検索'
     world_selection: '地域選択'
     not_authenticated: 'ログインしてください'
     not_authenticated_like_info_json: 'ログインすればいいねができます！'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -112,6 +112,8 @@ ja:
   avatar_tags:
     show:
       title: "「%{name}」タグ"
+    index:
+      title: '推しタグ一覧'
   shared:
     description_modal:
       title: '利用制限と注意事項'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -70,6 +70,7 @@ ja:
       title: 'プロフィール編集'
       have_avatar: 'アバターが登録されています'
       no_avatar: 'アバターは登録されていません'
+      search_tags: '検索されたタグ'
     update:
       success: "%{item}の編集に成功しました"
       fail: "%{item}の編集に失敗しました"
@@ -106,6 +107,9 @@ ja:
     create:
       success: "%{name}さんの「%{post}」をいいねしました"
       fail: "%{name}さんの「%{post}」はすでにいいねされています"
+  avatar_tags:
+    show:
+      title: "「%{name}」タグ"
   shared:
     description_modal:
       title: '利用制限と注意事項'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@
 #                               tweet_like DELETE /tweets/:tweet_id/like(.:format)                                                                  likes#destroy
 #                                          POST   /tweets/:tweet_id/like(.:format)                                                                  likes#create
 #                                    tweet DELETE /tweets/:id(.:format)                                                                             tweets#destroy
+#                              avatar_tags GET    /avatar_tags(.:format)                                                                            avatar_tags#index
+#                               avatar_tag GET    /avatar_tags/:id(.:format)                                                                        avatar_tags#show
 #                                          GET    /*path(.:format)                                                                                  application#routing_error
 #         turbo_recede_historical_location GET    /recede_historical_location(.:format)                                                             turbo/native/navigation#recede
 #         turbo_resume_historical_location GET    /resume_historical_location(.:format)                                                             turbo/native/navigation#resume
@@ -68,13 +70,17 @@ Rails.application.routes.draw do
   resource :profile, only: %i[show edit update] do
     delete :destroy_avatar, on: :collection
   end
-
+  
   resources :worlds, only: %i[show index], param: 'place_name' do
     resources :tweets, only: %i[create]
   end
-
+  
   resources :tweets, only: %i[destroy] do
     resource :like, only: %i[create destroy]
+  end
+
+  resources :avatar_tags, only: %i[show index create] do
+    get :search, on: :collection
   end
 
   get '*path', to: 'application#routing_error', constraints: lambda { |req|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,9 @@
 #                               tweet_like DELETE /tweets/:tweet_id/like(.:format)                                                                  likes#destroy
 #                                          POST   /tweets/:tweet_id/like(.:format)                                                                  likes#create
 #                                    tweet DELETE /tweets/:id(.:format)                                                                             tweets#destroy
+#                       search_avatar_tags GET    /avatar_tags/search(.:format)                                                                     avatar_tags#search
 #                              avatar_tags GET    /avatar_tags(.:format)                                                                            avatar_tags#index
-#                               avatar_tag GET    /avatar_tags/:id(.:format)                                                                        avatar_tags#show
+#                               avatar_tag GET    /avatar_tags/:avatar_tag_name(.:format)                                                           avatar_tags#show
 #                                          GET    /*path(.:format)                                                                                  application#routing_error
 #         turbo_recede_historical_location GET    /recede_historical_location(.:format)                                                             turbo/native/navigation#recede
 #         turbo_resume_historical_location GET    /resume_historical_location(.:format)                                                             turbo/native/navigation#resume
@@ -70,16 +71,16 @@ Rails.application.routes.draw do
   resource :profile, only: %i[show edit update] do
     delete :destroy_avatar, on: :collection
   end
-  
+
   resources :worlds, only: %i[show index], param: 'place_name' do
     resources :tweets, only: %i[create]
   end
-  
+
   resources :tweets, only: %i[destroy] do
     resource :like, only: %i[create destroy]
   end
 
-  resources :avatar_tags, only: %i[show index create] do
+  resources :avatar_tags, only: %i[show index], param: 'avatar_tag_name' do
     get :search, on: :collection
   end
 

--- a/db/migrate/20230223141503_create_avatar_tags.rb
+++ b/db/migrate/20230223141503_create_avatar_tags.rb
@@ -1,0 +1,9 @@
+class CreateAvatarTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :avatar_tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230223141503_create_avatar_tags.rb
+++ b/db/migrate/20230223141503_create_avatar_tags.rb
@@ -5,5 +5,6 @@ class CreateAvatarTags < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
+    add_index :avatar_tags, :name, unique: true
   end
 end

--- a/db/migrate/20230223141927_create_avatar_tag_maps.rb
+++ b/db/migrate/20230223141927_create_avatar_tag_maps.rb
@@ -1,0 +1,11 @@
+class CreateAvatarTagMaps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :avatar_tag_maps do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :avatar_tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :avatar_tag_maps, [:user_id, :avatar_tag_id], unique: true
+  end
+end

--- a/db/migrate/20230223141927_create_avatar_tag_maps.rb
+++ b/db/migrate/20230223141927_create_avatar_tag_maps.rb
@@ -6,6 +6,6 @@ class CreateAvatarTagMaps < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
-    add_index :avatar_tag_maps, [:user_id, :avatar_tag_id], unique: true
+    add_index :avatar_tag_maps, %i[user_id avatar_tag_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_23_141927) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_avatar_tags_on_name", unique: true
   end
 
   create_table "likes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_13_201718) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_23_141927) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_201718) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "avatar_tag_maps", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "avatar_tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["avatar_tag_id"], name: "index_avatar_tag_maps_on_avatar_tag_id"
+    t.index ["user_id", "avatar_tag_id"], name: "index_avatar_tag_maps_on_user_id_and_avatar_tag_id", unique: true
+    t.index ["user_id"], name: "index_avatar_tag_maps_on_user_id"
+  end
+
+  create_table "avatar_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "likes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -74,6 +90,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_201718) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "avatar_tag_maps", "avatar_tags"
+  add_foreign_key "avatar_tag_maps", "users"
   add_foreign_key "likes", "tweets"
   add_foreign_key "likes", "users"
   add_foreign_key "tweets", "users"


### PR DESCRIPTION
# 概要
- model追加
  - userと多対多の関係にある avatar_tag 追加
  - 中間テーブル avatar_tag_map 追加
- profile編集ページでタグが作成、追加できる処理追加
  -  params `avatar_tag_ids: []` は既存のタグのチェックボックス用
  -  params `avatar_tags_attributes: [:name]` はuserモデルの編集と同時にavatar_tagsも追加できる様にパラメーターに入れたもの
     - models/user.rbの `accepts_nested_attributes_for` 確認
- avatar_tag view追加
  - show -> タグづけられているuserの表示
  - index -> タグ一覧

issue https://github.com/isseiezawa/Humans-Like-Ants/issues/77