### PR TITLE
つぶやきがどこで投稿されたかを表示させる処理追加

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,7 +2,7 @@ class ProfilesController < ApplicationController
   before_action :set_user, only: %i[edit update destroy_avatar]
 
   def show
-    @tweets = current_user.tweets.includes(:likes).with_attached_image.order(id: :desc).page(params[:page]).per(3)
+    @tweets = current_user.tweets.includes(:likes, :world_room).with_attached_image.order(id: :desc).page(params[:page]).per(3)
 
     render 'users/scrollable_list' if params[:page]
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[show new create]
 
   def show
-    @tweets = @user.tweets.includes(:likes).with_attached_image.order(id: :desc).page(params[:page]).per(3)
+    @tweets = @user.tweets.includes(:likes, :world_room).with_attached_image.order(id: :desc).page(params[:page]).per(3)
 
     render 'scrollable_list' if params[:page]
   end
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
   end
 
   def likes
-    @liked_tweets = @user.liked_tweets.includes(:user, :likes).with_attached_image.order(id: :desc)
+    @liked_tweets = @user.liked_tweets.includes(:user, :likes, :world_room).with_attached_image.order(id: :desc)
   end
 
   private

--- a/app/views/users/_liked_tweet.html.slim
+++ b/app/views/users/_liked_tweet.html.slim
@@ -3,6 +3,10 @@
     .fw-bold.my-1
       = link_to user_path(liked_tweet.user.id), class: 'default-link' do
         = liked_tweet.user.name
+    .small.border.rounded.w-75.mx-auto.my-1
+      = link_to liked_tweet.world_room.world.place_ja, world_path(liked_tweet.world_room.world.place), class: 'default-link'
+      span  → 
+      = link_to liked_tweet.world_room.name, world_room_path(liked_tweet.world_room), class: 'default-link'
     .small.mb-1.text-black-50
       = l(liked_tweet.created_at, format: :long)
     .small.fw-bold.mb-2

--- a/app/views/users/_tweet.html.slim
+++ b/app/views/users/_tweet.html.slim
@@ -1,6 +1,10 @@
 #tweets
   .border.rounded-3.shadow.py-3.my-2.mx-5 id="tweet_#{tweet.id}"
     .d-flex.flex-column
+      .small.border.rounded.w-75.mx-auto.my-1
+        = link_to tweet.world_room.world.place_ja, world_path(tweet.world_room.world.place), class: 'default-link'
+        span  → 
+        = link_to tweet.world_room.name, world_room_path(tweet.world_room), class: 'default-link'
       .small.text-secondary.mb-1
         = l(tweet.created_at, format: :long)
       .fw-bold.mb-2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@
 #
 #                                   Prefix Verb   URI Pattern                                                                                       Controller#Action
 #                                     root GET    /                                                                                                 static_pages#top
+#                                    guide GET    /guide(.:format)                                                                                  static_pages#guide
 #                                    login GET    /login(.:format)                                                                                  user_sessions#new
 #                                          POST   /login(.:format)                                                                                  user_sessions#create
 #                                   logout DELETE /logout(.:format)                                                                                 user_sessions#destroy
@@ -26,6 +27,7 @@
 #                                    world GET    /worlds/:place_name(.:format)                                                                     worlds#show
 #                               tweet_like DELETE /tweets/:tweet_id/like(.:format)                                                                  likes#destroy
 #                                          POST   /tweets/:tweet_id/like(.:format)                                                                  likes#create
+#                              likes_tweet GET    /tweets/:id/likes(.:format)                                                                       tweets#likes
 #                                    tweet DELETE /tweets/:id(.:format)                                                                             tweets#destroy
 #                       search_avatar_tags GET    /avatar_tags/search(.:format)                                                                     avatar_tags#search
 #                              avatar_tags GET    /avatar_tags(.:format)                                                                            avatar_tags#index


### PR DESCRIPTION
# 概要
- N+1対策各所tweetにworld_roomを含ませる処理のみ追加。worldはactive hashでありデータベースを参照しないため。